### PR TITLE
Fix javadoc for keto authorization provider

### DIFF
--- a/common/src/main/java/feast/common/auth/providers/keto/KetoAuthorizationProvider.java
+++ b/common/src/main/java/feast/common/auth/providers/keto/KetoAuthorizationProvider.java
@@ -43,7 +43,6 @@ public class KetoAuthorizationProvider implements AuthorizationProvider {
      * Initialized builder for Keto authorization provider.
      *
      * @param url Url string for Keto server.
-     * @return Returns Builder
      */
     public Builder(String url) {
       this.url = url;


### PR DESCRIPTION
A bug was introduced in https://github.com/feast-dev/feast-java/pull/7, in which the packaging failed due to javadoc errors. This PR fixed it.