### PR TITLE
Add Development Guide for feast-java Feast Components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ the feast-java Repository:
 - [Feast Serving](#feast-serving)
 - [Feast Java Client](#feast-java-client)
 
-> Don't see the Feast Component that you want to contribute to here?  
+> Don't see the Feast component that you want to contribute to here?  
 > Check out the [Development Guide](https://docs.feast.dev/contributing/development-guide)
 > to learn how Feast components are distributed over multiple repositories.
 
@@ -24,12 +24,12 @@ git submodule update --recursive
 - Java SE Development Kit 11, Maven 3.6, `make`
 
 #### Code Style
-feast-java's Java codebase conforms to the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+feast-java's codebase conforms to the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 
 Automatically format the code to conform the style guide by:
 
 ```sh
-# formats all java code in the feast-java repository
+# formats all code in the feast-java repository
 mvn spotless:apply
 ```
 
@@ -58,7 +58,7 @@ make build-docker REGISTRY=gcr.io/kf-feast VERSION=develop
 
 ## Feast Core
 ### Environment Setup
-Setting up your Development Environment for Feast Core:
+Setting up your development environment for Feast Core:
 1. Complete the feast-java [Common Setup](#common-setup)
 2. Boot up a PostgreSQL instance (version 11 and above). Example of doing so via Docker:
 ```sh
@@ -98,7 +98,7 @@ mvn verify -pl core --also-make
 
 ## Feast Serving
 ### Environment Setup
-Setting up your Development Environment for Feast Serving:
+Setting up your development environment for Feast Serving:
 1. Complete the feast-java [Common Setup](#common-setup)
 2. Boot up a Redis instance (version 5.x). Example of doing so via Docker:
 ```sh
@@ -134,14 +134,14 @@ mvn verify -pl serving --also-make
 
 ## Feast Java Client
 ### Environment Setup
-Setting up your Development Environment for Feast Java SDK:
+Setting up your development environment for Feast Java SDK:
 1. Complete the feast-java [Common Setup](#common-setup)
 
 > Feast Java Client is a Java Client for retrieving Features from a running Feast Serving instance.  
 > See the [Feast Serving Section](#feast-serving) section for how to get a Feast Serving instance running.
 
 ### Configuration
-Feast Java Client is [configured using Java code](https://docs.feast.dev/v/master/reference/configuration-reference#4-feast-java-and-go-sdk)
+Feast Java Client is [configured as code](https://docs.feast.dev/v/master/reference/configuration-reference#4-feast-java-and-go-sdk)
 
 ### Building
 1. Build / Compile Feast Java Client with Maven:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Development Guide: feast-java
+> The higher level [Development Guide](https://docs.feast.dev/contributing/development-guide)
+> gives contributing to Feast codebase as a whole.
+
+### Overview
+This guide is targeted at developers looking to contribute to Feast components in
+the feast-java Repository:
+- [Feast Core](#feast-core)
+- [Feast Serving](#feast-serving)
+- [Feast Java Client](#feast-java-client)
+
+> Don't see the Feast Component that you want to contribute to here?  
+> Check out the [Development Guide](https://docs.feast.dev/contributing/development-guide)
+> to learn how Feast components are distributed over multiple repositories.
+
+#### Common Setup
+Common Environment Setup for all feast-java Feast components:
+1. feast-java contains submodules that need to be updated:
+```sh
+git submodule init
+git submodule update --recursive
+```
+2. Ensure following development tools are installed:
+- Java SE Development Kit 11, Maven 3.6, `make`
+
+#### Code Style
+feast-java's Java codebase conforms to the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+
+Automatically format the code to conform the style guide by:
+
+```sh
+# formats all java code in the feast-java repository
+mvn spotless:apply
+```
+
+> If you're using IntelliJ, you can import these [code style settings](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
+> if you'd like to use the IDE's reformat function.
+
+## Feast Core
+### Environment Setup
+Setting up your Development Environment for Feast Core:
+1. Complete the feast-java [Common Setup](#common-setup)
+2. Boot up a PostgreSQL instance (version 11 and above). Example of doing so via Docker:
+```sh
+# spawn a PostgreSQL instance as a Docker container running in the background
+docker run \
+    --rm -it -d \
+    --name postgres \
+    -e POSTGRES_DB=postgres \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=password \
+    -p 5432:5432 postgres:12-alpine
+```
+
+### Configuration
+Feast Core is configured using it's [application.yml](https://docs.feast.dev/reference/configuration-reference#1-feast-core-and-feast-online-serving).
+
+### Building and Running
+1. Build / Compile Feast Core with Maven to produce an executable Feast Core JAR
+```sh
+mvn package -pl core --also-make -Dmaven.test.skip=true 
+```
+
+2. Run Feast Core using the built JAR:
+```sh
+# where X.X.X is the version of the Feast Core JAR built
+java -jar core/target/feast-core-X.X.X-exec.jar
+```
+
+### Unit / Integration Tests
+Unit &amp; Integration Tests can be used to verify functionality:
+```sh
+# run unit tests
+mvn test -pl core --also-make
+# run integration tests
+mvn verify -pl core --also-make
+```
+
+## Feast Serving
+### Environment Setup
+Setting up your Development Environment for Feast Serving:
+1. Complete the feast-java [Common Setup](#common-setup)
+2. Boot up a Redis instance (version 5.x). Example of doing so via Docker:
+```sh
+docker run --name redis --rm -it -d -p 6379:6379 redis:5-alpine
+```
+
+> Feast Serving requires a running Feast Core instance to retrieve Feature metadata
+> in order to serve features. See the [Feast Core section](#feast-core) for
+> how to get a Feast Core instance running.  
+ 
+### Configuration
+Feast Serving is configured using it's [application.yml](https://docs.feast.dev/reference/configuration-reference#1-feast-core-and-feast-online-serving).
+
+### Building and Running
+1. Build / Compile Feast Serving with Maven to produce an executable Feast Serving JAR
+```sh
+mvn package -pl serving --also-make -Dmaven.test.skip=true 
+
+2. Run Feast Serving using the built JAR:
+```sh
+# where X.X.X is the version of the Feast serving JAR built
+java -jar serving/target/feast-serving-X.X.X-exec.jar
+```
+
+### Unit / Integration Tests
+Unit &amp; Integration Tests can be used to verify functionality:
+```sh
+# run unit tests
+mvn test -pl serving --also-make
+# run integration tests
+mvn verify -pl serving --also-make
+```
+
+## Feast Java Client
+### Environment Setup
+Setting up your Development Environment for Feast Java SDK:
+1. Complete the feast-java [Common Setup](#common-setup)
+
+> Feast Java Client is a Java Client for retrieving Features from a running Feast Serving instance.  
+> See the [Feast Serving Section](#feast-serving) section for how to get a Feast Serving instance running.
+
+### Configuration
+Feast Java Client is [configured using Java code](https://docs.feast.dev/v/master/reference/configuration-reference#4-feast-java-and-go-sdk)
+
+### Building
+1. Build / Compile Feast Java Client with Maven:
+
+```sh
+mvn package -pl sdk/java --also-make -Dmaven.test.skip=true
+```
+
+### Unit Tests
+Unit Tests can be used to verify functionality:
+
+```sh
+mvn package -pl sdk/java test --also-make
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,26 @@ mvn spotless:apply
 > If you're using IntelliJ, you can import these [code style settings](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
 > if you'd like to use the IDE's reformat function.
 
+#### Project Makefile
+The Project Makefile provides useful shorthands for common development tasks:
+
+
+Run all Unit tests:
+```
+make test-java
+```
+
+Run all Integration tests:
+```
+make test-java-integration
+```
+
+Building Docker images for Feast Core &amp; Feast Serving:
+```
+make build-docker REGISTRY=gcr.io/kf-feast VERSION=develop
+```
+
+
 ## Feast Core
 ### Environment Setup
 Setting up your Development Environment for Feast Core:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains the following Feast components.
 Guides on Contributing:
 - [Contribution Process for Feast](https://docs.feast.dev/v/master/contributing/contributing)
 - [Development Guide for Feast](https://docs.feast.dev/contributing/development-guide)
-- [Development Guide for feast-java](./CONTRIBUTING.md)
+- [Development Guide for feast-java (this repository)](./CONTRIBUTING.md)
 
 ### Installing using Helm
 Please see the Helm charts in [charts](infra/charts).

--- a/README.md
+++ b/README.md
@@ -19,28 +19,11 @@ This repository contains the following Feast components.
 * Feast Serving has a dependency on Feast Core.
 * The Go and Python Clients are not a part of this repository.
 
-### Running tests
-
-To run unit tests:
-
-```
-make test-java
-```
-
-To run integration tests:
-
-```
-make test-java-integration
-```
-
-### Building docker images
-
-In order to build development versions of the Core and Serving images, please run the following commands:
-
-```
-build-docker REGISTRY=gcr.io/kf-feast VERSION=develop
-```
+### Contributing
+Guides on Contributing:
+- [Contribution Process for Feast](https://docs.feast.dev/v/master/contributing/contributing)
+- [Development Guide for Feast](https://docs.feast.dev/contributing/development-guide)
+- [Development Guide for feast-java](./CONTRIBUTING.md)
 
 ### Installing using Helm
-
 Please see the Helm charts in [charts](infra/charts).


### PR DESCRIPTION
### Why this PR
Partly implement  feast-dev/feast#1353 for the `feast-java` Feast components

### What this PR does
- Moves Development Guide docs for `feast-java` components out of central Development Guide on Gitbook into individual `CONTRIBIUTING.md` in repositories.
- Updates Development Guide docs for new repository structure [(Preview)](https://github.com/mrzzy/feast-java/blob/chore/add-dev-guide/CONTRIBUTING.md)
- Moves the instructions targeted at developers on `README` to `CONTRIBUTING.md`
- Add Links to relevant docs ie `CONTRIBUTING.md`  on the `README`.