### PR TITLE
Add support for Cassandra Online Storage

### DIFF
--- a/common-test/src/main/java/feast/common/it/DataGenerator.java
+++ b/common-test/src/main/java/feast/common/it/DataGenerator.java
@@ -249,6 +249,10 @@ public class DataGenerator {
     return ValueProto.Value.newBuilder().setDoubleVal(value).build();
   }
 
+  public static ValueProto.Value createInt32Value(int value) {
+    return ValueProto.Value.newBuilder().setInt32Val(value).build();
+  }
+
   public static ValueProto.Value createInt64Value(long value) {
     return ValueProto.Value.newBuilder().setInt64Val(value).build();
   }

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -349,12 +349,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>cassandra</artifactId>
-      <version>1.15.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>3.0.0</version>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -92,6 +92,12 @@
 
     <dependency>
       <groupId>dev.feast</groupId>
+      <artifactId>feast-storage-connector-cassandra</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.feast</groupId>
       <artifactId>feast-common</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -339,6 +345,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>gcloud</artifactId>
+      <version>1.15.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>cassandra</artifactId>
       <version>1.15.2</version>
       <scope>test</scope>
     </dependency>

--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -321,7 +321,8 @@ public class FeastProperties {
       return new CassandraStoreConfig(
           this.config.get("host"),
           Integer.valueOf(this.config.get("port")),
-          this.config.get("data_center"));
+          this.config.get("data_center"),
+          this.config.get("keyspace"));
     }
 
     /**

--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -319,8 +319,7 @@ public class FeastProperties {
 
     public CassandraStoreConfig getCassandraConfig() {
       return new CassandraStoreConfig(
-          this.config.get("host"),
-          Integer.valueOf(this.config.get("port")),
+          this.config.get("connection_string"),
           this.config.get("data_center"),
           this.config.get("keyspace"));
     }

--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -27,6 +27,7 @@ import feast.common.auth.config.SecurityProperties.AuthorizationProperties;
 import feast.common.auth.credentials.CoreAuthenticationProperties;
 import feast.common.logging.config.LoggingProperties;
 import feast.storage.connectors.bigtable.retriever.BigTableStoreConfig;
+import feast.storage.connectors.cassandra.retriever.CassandraStoreConfig;
 import feast.storage.connectors.redis.retriever.RedisClusterStoreConfig;
 import feast.storage.connectors.redis.retriever.RedisStoreConfig;
 import io.lettuce.core.ReadFrom;
@@ -270,7 +271,7 @@ public class FeastProperties {
     }
 
     /**
-     * Gets the store type. Example are REDIS, REDIS_CLUSTER or BIGTABLE
+     * Gets the store type. Example are REDIS, REDIS_CLUSTER, BIGTABLE or CASSANDRA
      *
      * @return the store type as a String.
      */
@@ -316,6 +317,13 @@ public class FeastProperties {
       return new BigTableStoreConfig(this.config.get("project_id"), this.config.get("instance_id"));
     }
 
+    public CassandraStoreConfig getCassandraConfig() {
+      return new CassandraStoreConfig(
+          this.config.get("host"),
+          Integer.valueOf(this.config.get("port")),
+          this.config.get("data_center"));
+    }
+
     /**
      * Sets the store config. Please protos/feast/core/Store.proto for the specific options for each
      * store.
@@ -329,6 +337,7 @@ public class FeastProperties {
 
   public enum StoreType {
     BIGTABLE,
+    CASSANDRA,
     REDIS,
     REDIS_CLUSTER;
   }

--- a/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
+++ b/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
@@ -16,6 +16,8 @@
  */
 package feast.serving.config;
 
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import feast.serving.service.OnlineServingServiceV2;
@@ -24,9 +26,12 @@ import feast.serving.specs.CachedSpecService;
 import feast.storage.api.retriever.OnlineRetrieverV2;
 import feast.storage.connectors.bigtable.retriever.BigTableOnlineRetriever;
 import feast.storage.connectors.bigtable.retriever.BigTableStoreConfig;
+import feast.storage.connectors.cassandra.retriever.CassandraOnlineRetriever;
+import feast.storage.connectors.cassandra.retriever.CassandraStoreConfig;
 import feast.storage.connectors.redis.retriever.*;
 import io.opentracing.Tracer;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -76,6 +81,20 @@ public class ServingServiceConfigV2 {
         BigtableDataClient bigtableClient = context.getBean(BigtableDataClient.class);
         OnlineRetrieverV2 bigtableRetriever = new BigTableOnlineRetriever(bigtableClient);
         servingService = new OnlineServingServiceV2(bigtableRetriever, specService, tracer);
+        break;
+      case CASSANDRA:
+        CassandraStoreConfig config = feastProperties.getActiveStore().getCassandraConfig();
+        String host = config.getHost();
+        Integer port = config.getPort();
+        String dataCenter = config.getDataCenter();
+
+        CqlSession session =
+            new CqlSessionBuilder()
+                .addContactPoint(new InetSocketAddress(host, port))
+                .withLocalDatacenter(dataCenter)
+                .build();
+        OnlineRetrieverV2 cassandraRetriever = new CassandraOnlineRetriever(session);
+        servingService = new OnlineServingServiceV2(cassandraRetriever, specService, tracer);
         break;
     }
 

--- a/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
+++ b/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
@@ -87,11 +87,13 @@ public class ServingServiceConfigV2 {
         String host = config.getHost();
         Integer port = config.getPort();
         String dataCenter = config.getDataCenter();
+        String keySpace = config.getKeySpace();
 
         CqlSession session =
             new CqlSessionBuilder()
                 .addContactPoint(new InetSocketAddress(host, port))
                 .withLocalDatacenter(dataCenter)
+                .withKeyspace(keySpace)
                 .build();
         OnlineRetrieverV2 cassandraRetriever = new CassandraOnlineRetriever(session);
         servingService = new OnlineServingServiceV2(cassandraRetriever, specService, tracer);

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -59,6 +59,12 @@ feast:
       config:
         project_id: <gcp_project>
         instance_id: <gcp_bigtable_instance>
+    - name: cassandra
+      type: CASSANDRA
+      config:
+        host: localhost
+        port: 9094
+        data_center: datacenter1
   tracing:
     # If true, Feast will provide tracing data (using OpenTracing API) for various RPC method calls
     # which can be useful to debug performance issues and perform benchmarking

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -62,8 +62,7 @@ feast:
     - name: cassandra
       type: CASSANDRA
       config:
-        host: localhost
-        port: 9042
+        connection_string: localhost:9042
         data_center: datacenter1
         keyspace: feast
   tracing:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -63,8 +63,9 @@ feast:
       type: CASSANDRA
       config:
         host: localhost
-        port: 9094
+        port: 9042
         data_center: datacenter1
+        keyspace: feast
   tracing:
     # If true, Feast will provide tracing data (using OpenTracing API) for various RPC method calls
     # which can be useful to debug performance issues and perform benchmarking

--- a/serving/src/test/java/feast/serving/it/BaseAuthIT.java
+++ b/serving/src/test/java/feast/serving/it/BaseAuthIT.java
@@ -54,6 +54,10 @@ public class BaseAuthIT {
   static final String BIGTABLE = "bigtable_1";
   static final int BIGTABLE_PORT = 8086;
 
+  static final String CASSANDRA = "cassandra_1";
+  static final int CASSANDRA_PORT = 9042;
+  static final String CASSANDRA_DATACENTER = "datacenter1";
+
   static final int FEAST_CORE_PORT = 6565;
 
   @DynamicPropertySource
@@ -79,6 +83,21 @@ public class BaseAuthIT {
     registry.add("feast.stores[1].type", () -> "BIGTABLE");
     registry.add("feast.stores[1].config.project_id", () -> "test-project");
     registry.add("feast.stores[1].config.instance_id", () -> "test-instance");
+
+    registry.add("feast.stores[2].name", () -> "cassandra");
+    registry.add("feast.stores[2].type", () -> "CASSANDRA");
+    registry.add(
+        "feast.stores[2].config.host",
+        () -> {
+          try {
+            return InetAddress.getLocalHost().getHostAddress();
+          } catch (UnknownHostException e) {
+            e.printStackTrace();
+            return "";
+          }
+        });
+    registry.add("feast.stores[2].config.port", () -> CASSANDRA_PORT);
+    registry.add("feast.stores[2].config.data_center", () -> CASSANDRA_DATACENTER);
 
     registry.add("feast.core-authentication.options.oauth_url", () -> TOKEN_URL);
     registry.add("feast.core-authentication.options.grant_type", () -> GRANT_TYPE);

--- a/serving/src/test/java/feast/serving/it/BaseAuthIT.java
+++ b/serving/src/test/java/feast/serving/it/BaseAuthIT.java
@@ -57,6 +57,7 @@ public class BaseAuthIT {
   static final String CASSANDRA = "cassandra_1";
   static final int CASSANDRA_PORT = 9042;
   static final String CASSANDRA_DATACENTER = "datacenter1";
+  static final String CASSANDRA_KEYSPACE = "feast";
 
   static final int FEAST_CORE_PORT = 6565;
 
@@ -98,6 +99,7 @@ public class BaseAuthIT {
         });
     registry.add("feast.stores[2].config.port", () -> CASSANDRA_PORT);
     registry.add("feast.stores[2].config.data_center", () -> CASSANDRA_DATACENTER);
+    registry.add("feast.stores[2].config.keyspace", () -> CASSANDRA_KEYSPACE);
 
     registry.add("feast.core-authentication.options.oauth_url", () -> TOKEN_URL);
     registry.add("feast.core-authentication.options.grant_type", () -> GRANT_TYPE);

--- a/serving/src/test/java/feast/serving/it/BaseAuthIT.java
+++ b/serving/src/test/java/feast/serving/it/BaseAuthIT.java
@@ -58,6 +58,7 @@ public class BaseAuthIT {
   static final int CASSANDRA_PORT = 9042;
   static final String CASSANDRA_DATACENTER = "datacenter1";
   static final String CASSANDRA_KEYSPACE = "feast";
+  static final String CASSANDRA_SCHEMA_TABLE = "feast_schema_reference";
 
   static final int FEAST_CORE_PORT = 6565;
 

--- a/serving/src/test/java/feast/serving/it/BaseAuthIT.java
+++ b/serving/src/test/java/feast/serving/it/BaseAuthIT.java
@@ -59,6 +59,7 @@ public class BaseAuthIT {
   static final String CASSANDRA_DATACENTER = "datacenter1";
   static final String CASSANDRA_KEYSPACE = "feast";
   static final String CASSANDRA_SCHEMA_TABLE = "feast_schema_reference";
+  static final String CASSANDRA_ENTITY_KEY = "key";
 
   static final int FEAST_CORE_PORT = 6565;
 

--- a/serving/src/test/java/feast/serving/it/BaseAuthIT.java
+++ b/serving/src/test/java/feast/serving/it/BaseAuthIT.java
@@ -79,8 +79,6 @@ public class BaseAuthIT {
           }
         });
     registry.add("feast.stores[0].config.port", () -> REDIS_PORT);
-    registry.add("feast.stores[0].subscriptions[0].name", () -> "*");
-    registry.add("feast.stores[0].subscriptions[0].project", () -> "*");
 
     registry.add("feast.stores[1].name", () -> "bigtable");
     registry.add("feast.stores[1].type", () -> "BIGTABLE");
@@ -99,7 +97,19 @@ public class BaseAuthIT {
             return "";
           }
         });
-    registry.add("feast.stores[2].config.port", () -> CASSANDRA_PORT);
+
+    registry.add(
+        "feast.stores[2].config.connection_string",
+        () -> {
+          String hostAddress = "";
+          try {
+            hostAddress = InetAddress.getLocalHost().getHostAddress();
+          } catch (UnknownHostException e) {
+            e.printStackTrace();
+          }
+
+          return String.format("%s:%s", hostAddress, CASSANDRA_PORT);
+        });
     registry.add("feast.stores[2].config.data_center", () -> CASSANDRA_DATACENTER);
     registry.add("feast.stores[2].config.keyspace", () -> CASSANDRA_KEYSPACE);
 

--- a/serving/src/test/java/feast/serving/it/ServingServiceCassandraIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceCassandraIT.java
@@ -1,0 +1,268 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import feast.common.it.DataGenerator;
+import feast.proto.core.EntityProto;
+import feast.proto.serving.ServingAPIProto;
+import feast.proto.serving.ServingServiceGrpc;
+import feast.proto.types.ValueProto;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@ActiveProfiles("it")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "feast.core-cache-refresh-interval=1",
+      "feast.active_store=cassandra",
+      "spring.main.allow-bean-definition-overriding=true"
+    })
+@Testcontainers
+public class ServingServiceCassandraIT extends BaseAuthIT {
+
+  static final Map<String, String> options = new HashMap<>();
+  static CoreSimpleAPIClient coreClient;
+  static ServingServiceGrpc.ServingServiceBlockingStub servingStub;
+
+  static CqlSession cqlSession;
+  //    static Session session;
+  static final int FEAST_SERVING_PORT = 6570;
+
+  static final ServingAPIProto.FeatureReferenceV2 feature1Reference =
+      DataGenerator.createFeatureReference("rides", "trip_cost");
+  static final ServingAPIProto.FeatureReferenceV2 feature2Reference =
+      DataGenerator.createFeatureReference("rides", "trip_distance");
+  static final ServingAPIProto.FeatureReferenceV2 feature3Reference =
+      DataGenerator.createFeatureReference("rides", "trip_empty");
+  static final ServingAPIProto.FeatureReferenceV2 feature4Reference =
+      DataGenerator.createFeatureReference("rides", "trip_wrong_type");
+  static final String KEYSPACE = "feast";
+
+  @ClassRule @Container
+  public static DockerComposeContainer environment =
+      new DockerComposeContainer(
+              new File("src/test/resources/docker-compose/docker-compose-cassandra-it.yml"))
+          .withExposedService(
+              CORE,
+              FEAST_CORE_PORT,
+              Wait.forLogMessage(".*gRPC Server started.*\\n", 1)
+                  .withStartupTimeout(Duration.ofMinutes(SERVICE_START_MAX_WAIT_TIME_IN_MINUTES)))
+          .withExposedService(CASSANDRA, CASSANDRA_PORT);
+
+  @DynamicPropertySource
+  static void initialize(DynamicPropertyRegistry registry) {
+    registry.add("grpc.server.port", () -> FEAST_SERVING_PORT);
+  }
+
+  @BeforeAll
+  static void globalSetup() throws IOException {
+    coreClient = TestUtils.getApiClientForCore(FEAST_CORE_PORT);
+    servingStub = TestUtils.getServingServiceStub(false, FEAST_SERVING_PORT, null);
+
+    cqlSession =
+        CqlSession.builder()
+            .addContactPoint(
+                new InetSocketAddress(
+                    environment.getServiceHost("cassandra_1", CASSANDRA_PORT),
+                    environment.getServicePort("cassandra_1", CASSANDRA_PORT)))
+            .withLocalDatacenter(CASSANDRA_DATACENTER)
+            .build();
+
+    /** Feast resource creation Workflow */
+    String projectName = "default";
+    // Apply Entity (driver_id)
+    String driverEntityName = "driver_id";
+    String driverEntityDescription = "My driver id";
+    ValueProto.ValueType.Enum driverEntityType = ValueProto.ValueType.Enum.INT64;
+    EntityProto.EntitySpecV2 driverEntitySpec =
+        EntityProto.EntitySpecV2.newBuilder()
+            .setName(driverEntityName)
+            .setDescription(driverEntityDescription)
+            .setValueType(driverEntityType)
+            .build();
+    TestUtils.applyEntity(coreClient, projectName, driverEntitySpec);
+
+    // Apply Entity (merchant_id)
+    String merchantEntityName = "merchant_id";
+    String merchantEntityDescription = "My driver id";
+    ValueProto.ValueType.Enum merchantEntityType = ValueProto.ValueType.Enum.INT64;
+    EntityProto.EntitySpecV2 merchantEntitySpec =
+        EntityProto.EntitySpecV2.newBuilder()
+            .setName(merchantEntityName)
+            .setDescription(merchantEntityDescription)
+            .setValueType(merchantEntityType)
+            .build();
+    TestUtils.applyEntity(coreClient, projectName, merchantEntitySpec);
+
+    // Apply FeatureTable (rides)
+    String ridesFeatureTableName = "rides";
+    ImmutableList<String> ridesEntities = ImmutableList.of(driverEntityName);
+    ImmutableMap<String, ValueProto.ValueType.Enum> ridesFeatures =
+        ImmutableMap.of(
+            "trip_cost",
+            ValueProto.ValueType.Enum.INT64,
+            "trip_distance",
+            ValueProto.ValueType.Enum.DOUBLE,
+            "trip_empty",
+            ValueProto.ValueType.Enum.DOUBLE,
+            "trip_wrong_type",
+            ValueProto.ValueType.Enum.STRING);
+    TestUtils.applyFeatureTable(
+        coreClient, projectName, ridesFeatureTableName, ridesEntities, ridesFeatures, 7200);
+
+    cqlSession.execute(String.format("DROP KEYSPACE IF EXISTS %s", KEYSPACE));
+
+    cqlSession.execute(
+        String.format(
+            "CREATE KEYSPACE %s WITH replication = \n"
+                + "{'class':'SimpleStrategy','replication_factor':'1'};",
+            KEYSPACE));
+
+    ImmutableList.of(driverEntityName, merchantEntityName);
+    String cassandraTableName = String.format("%s__%s", projectName, driverEntityName);
+
+    cqlSession.execute(
+        String.format(
+            "CREATE TABLE IF NOT EXISTS %s.%s (key BLOB, schema_ref BLOB, PRIMARY KEY (key));",
+            KEYSPACE, cassandraTableName));
+
+    // Add column families
+    cqlSession.execute(
+        String.format("ALTER TABLE %s.%s ADD (rides BLOB)", KEYSPACE, cassandraTableName));
+
+    /** Single Entity Ingestion Workflow */
+    Schema ftSchema =
+        SchemaBuilder.record("DriverData")
+            .namespace(ridesFeatureTableName)
+            .fields()
+            .requiredInt(feature1Reference.getName())
+            .requiredDouble(feature2Reference.getName())
+            .nullableString(feature3Reference.getName(), "null")
+            .requiredString(feature4Reference.getName())
+            .endRecord();
+    byte[] schemaReference =
+        Hashing.murmur3_32().hashBytes(ftSchema.toString().getBytes()).asBytes();
+
+    GenericRecord record =
+        new GenericRecordBuilder(ftSchema)
+            .set("trip_cost", 5)
+            .set("trip_distance", 3.5)
+            .set("trip_empty", null)
+            .set("trip_wrong_type", "test")
+            .build();
+    byte[] entityFeatureKey =
+        String.valueOf(DataGenerator.createInt64Value(1).getInt64Val()).getBytes();
+    byte[] entityFeatureValue = createEntityValue(ftSchema, schemaReference, record);
+    byte[] schemaKey = createSchemaKey(schemaReference);
+
+    PreparedStatement statement =
+        cqlSession.prepare(
+            String.format(
+                "INSERT INTO %s.%s (key, schema_ref, rides) VALUES (?, ?, ?)",
+                KEYSPACE, cassandraTableName));
+    cqlSession.execute(
+        statement.bind(
+            ByteBuffer.wrap(entityFeatureKey),
+            ByteBuffer.wrap(schemaKey),
+            ByteBuffer.wrap(entityFeatureValue)));
+  }
+
+  private static byte[] createSchemaKey(byte[] schemaReference) throws IOException {
+    ByteArrayOutputStream concatOutputStream = new ByteArrayOutputStream();
+    concatOutputStream.write(schemaReference);
+    byte[] schemaKey = concatOutputStream.toByteArray();
+
+    return schemaKey;
+  }
+
+  private static byte[] createEntityValue(
+      Schema schema, byte[] schemaReference, GenericRecord record) throws IOException {
+    // Entity-Feature Row
+    byte[] avroSerializedFeatures = recordToAvro(record, schema);
+
+    ByteArrayOutputStream concatOutputStream = new ByteArrayOutputStream();
+    concatOutputStream.write(schemaReference);
+    concatOutputStream.write("".getBytes());
+    concatOutputStream.write(avroSerializedFeatures);
+    byte[] entityFeatureValue = concatOutputStream.toByteArray();
+
+    return entityFeatureValue;
+  }
+
+  private static byte[] recordToAvro(GenericRecord datum, Schema schema) throws IOException {
+    GenericDatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+    writer.write(datum, encoder);
+    encoder.flush();
+
+    return output.toByteArray();
+  }
+
+  @Test
+  public void shouldRegisterSingleEntityAndGetOnlineFeatures() {
+    String projectName = "default";
+    String entityName = "driver_id";
+    String cassandraTableName = String.format("%s__%s", projectName, entityName);
+    byte[] entityFeatureKey =
+        String.valueOf(DataGenerator.createInt64Value(1).getInt64Val()).getBytes();
+    String featureTableName = "rides";
+
+    BoundStatement statement =
+        cqlSession
+            .prepare(
+                String.format("SELECT * FROM %s.%s WHERE key = ?", KEYSPACE, cassandraTableName))
+            .bind(ByteBuffer.wrap(entityFeatureKey));
+    Row row = cqlSession.execute(statement).one();
+
+    assertEquals(ByteBuffer.wrap(entityFeatureKey), row.getByteBuffer("key"));
+  }
+}

--- a/serving/src/test/java/feast/serving/it/ServingServiceCassandraIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceCassandraIT.java
@@ -40,7 +40,6 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -150,7 +149,7 @@ public class ServingServiceCassandraIT extends BaseAuthIT {
     ImmutableMap<String, ValueProto.ValueType.Enum> ridesFeatures =
         ImmutableMap.of(
             "trip_cost",
-            ValueProto.ValueType.Enum.INT64,
+            ValueProto.ValueType.Enum.INT32,
             "trip_distance",
             ValueProto.ValueType.Enum.DOUBLE,
             "trip_empty",
@@ -175,9 +174,7 @@ public class ServingServiceCassandraIT extends BaseAuthIT {
     /** Create Cassandra Tables Workflow */
     String cassandraTableName = String.format("%s__%s", projectName, driverEntityName);
     String compoundCassandraTableName =
-        String.format(
-            "%s__%s",
-            projectName, ridesMerchantEntities.stream().collect(Collectors.joining("__")));
+        String.format("%s__%s", projectName, String.join("__", ridesMerchantEntities));
 
     cqlSession.execute(String.format("DROP KEYSPACE IF EXISTS %s", CASSANDRA_KEYSPACE));
     cqlSession.execute(
@@ -327,7 +324,7 @@ public class ServingServiceCassandraIT extends BaseAuthIT {
             entityName,
             entityValue,
             FeatureV2.getFeatureStringRef(featureReference),
-            DataGenerator.createInt64Value(5),
+            DataGenerator.createInt32Value(5),
             FeatureV2.getFeatureStringRef(notFoundFeatureReference),
             DataGenerator.createEmptyValue());
 

--- a/serving/src/test/resources/docker-compose/docker-compose-cassandra-it.yml
+++ b/serving/src/test/resources/docker-compose/docker-compose-cassandra-it.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  core:
+    image: gcr.io/kf-feast/feast-core:develop
+    volumes:
+      - ./core/application-it.yml:/etc/feast/application.yml
+    environment:
+      DB_HOST: db
+    restart: on-failure
+    depends_on:
+      - db
+    ports:
+      - 6565:6565
+    command:
+      - java
+      - -jar
+      - /opt/feast/feast-core.jar
+      - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
+
+  db:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+
+  cassandra:
+    image: datastax/cassandra:4.0
+    ports:
+      - "9042:9042"

--- a/storage/api/src/main/java/feast/storage/api/retriever/StorageRetriever.java
+++ b/storage/api/src/main/java/feast/storage/api/retriever/StorageRetriever.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.api.retriever;
+
+import feast.proto.serving.ServingAPIProto;
+import feast.proto.types.ValueProto;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StorageRetriever {
+
+  /**
+   * Generate name of Cassandra table in the form of <feastProject>__<entityNames>
+   *
+   * @param project Name of Feast project
+   * @param entityNames List of entities used in retrieval call
+   * @return Name of Cassandra table
+   */
+  protected String getTableName(String project, List<String> entityNames) {
+    return String.format("%s__%s", project, entityNames.stream().collect(Collectors.joining("__")));
+  }
+
+  /**
+   * Convert Entity value from Feast valueType to String type. Currently only supports STRING_VAL,
+   * INT64_VAL, INT32_VAL and BYTES_VAL.
+   *
+   * @param v Entity value of Feast valueType
+   * @return String representation of Entity value
+   */
+  protected String valueToString(ValueProto.Value v) {
+    String stringRepr;
+    switch (v.getValCase()) {
+      case STRING_VAL:
+        stringRepr = v.getStringVal();
+        break;
+      case INT64_VAL:
+        stringRepr = String.valueOf(v.getInt64Val());
+        break;
+      case INT32_VAL:
+        stringRepr = String.valueOf(v.getInt32Val());
+        break;
+      case BYTES_VAL:
+        stringRepr = v.getBytesVal().toString();
+        break;
+      default:
+        throw new RuntimeException("Type is not supported to be entity");
+    }
+
+    return stringRepr;
+  }
+
+  /**
+   * Retrieve Cassandra table column families based on FeatureTable names.
+   *
+   * @param featureReferences List of feature references of features in retrieval call
+   * @return List of String of FeatureTable names
+   */
+  protected List<String> getColumnFamilies(
+      List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
+    return featureReferences.stream()
+        .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+}

--- a/storage/connectors/bigtable/pom.xml
+++ b/storage/connectors/bigtable/pom.xml
@@ -31,6 +31,12 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.feast</groupId>
+            <artifactId>feast-storage-connector-sstable</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
+++ b/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
@@ -28,7 +28,7 @@ import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow;
 import feast.storage.api.retriever.Feature;
 import feast.storage.api.retriever.NativeFeature;
 import feast.storage.api.retriever.OnlineRetrieverV2;
-import feast.storage.api.retriever.StorageRetriever;
+import feast.storage.connectors.sstable.retriever.SSTableOnlineRetriever;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
@@ -39,7 +39,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.*;
 
-public class BigTableOnlineRetriever extends StorageRetriever implements OnlineRetrieverV2 {
+public class BigTableOnlineRetriever implements SSTableOnlineRetriever, OnlineRetrieverV2 {
 
   private BigtableDataClient client;
   private BigTableSchemaRegistry schemaRegistry;
@@ -126,7 +126,7 @@ public class BigTableOnlineRetriever extends StorageRetriever implements OnlineR
       List<EntityRow> entityRows,
       List<FeatureReferenceV2> featureReferences,
       List<String> entityNames) {
-    List<String> columnFamilies = getColumnFamilies(featureReferences);
+    List<String> columnFamilies = getColumns(featureReferences);
     String tableName = getTableName(project, entityNames);
 
     List<ByteString> rowKeys =

--- a/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
+++ b/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
@@ -152,6 +152,7 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
     return StreamSupport.stream(client.readRows(rowQuery).spliterator(), false)
         .collect(Collectors.toMap(Row::getKey, Function.identity()));
   }
+
   /**
    * AvroRuntimeException is thrown if feature name does not exist in avro schema. Empty Object is
    * returned when null is retrieved from BigTable RowCell.
@@ -160,6 +161,7 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
    * @param value Value of BigTable cell where first 4 bytes represent the schema reference and
    *     remaining bytes represent avro-serialized features
    * @param featureReferences List of feature references
+   * @param reusedDecoder Decoder for decoding feature values
    * @param timestamp Timestamp of rowCell
    * @return @NativeFeature with retrieved value stored in BigTable RowCell
    * @throws IOException
@@ -206,5 +208,4 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
-
 }

--- a/storage/connectors/cassandra/pom.xml
+++ b/storage/connectors/cassandra/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>feast-storage-connectors</artifactId>
+        <groupId>dev.feast</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>feast-storage-connector-cassandra</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.10.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-core</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/storage/connectors/cassandra/pom.xml
+++ b/storage/connectors/cassandra/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.feast</groupId>
+            <artifactId>feast-storage-connector-sstable</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
             <version>4.11.0</version>

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -73,6 +73,7 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
   /**
    * Converts Cassandra rows into @NativeFeature type.
    *
+   * @param tableName Name of Cassandra table
    * @param rowKeys List of keys of rows to retrieve
    * @param rows Map of rowKey to Row related to it
    * @param featureReferences List of feature references
@@ -164,6 +165,17 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
         .collect(Collectors.toMap((Row row) -> row.getByteBuffer(ENTITY_KEY), Function.identity()));
   }
 
+  /**
+   * AvroRuntimeException is thrown if feature name does not exist in avro schema.
+   *
+   * @param schemaRefKey Schema reference key
+   * @param value Value of Cassandra cell where bytes represent avro-serialized features
+   * @param featureReferences List of feature references
+   * @param reusedDecoder Decoder for decoding feature values
+   * @param timestamp Timestamp of rowCell
+   * @return @NativeFeature with retrieved value stored in Cassandra cell
+   * @throws IOException
+   */
   private List<Feature> decodeFeatures(
       ByteBuffer schemaRefKey,
       ByteBuffer value,

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -26,7 +26,7 @@ import feast.proto.serving.ServingAPIProto;
 import feast.storage.api.retriever.Feature;
 import feast.storage.api.retriever.NativeFeature;
 import feast.storage.api.retriever.OnlineRetrieverV2;
-import feast.storage.api.retriever.StorageRetriever;
+import feast.storage.connectors.sstable.retriever.SSTableOnlineRetriever;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -39,7 +39,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
 
-public class CassandraOnlineRetriever extends StorageRetriever implements OnlineRetrieverV2 {
+public class CassandraOnlineRetriever implements SSTableOnlineRetriever, OnlineRetrieverV2 {
 
   private final CqlSession session;
   private final CassandraSchemaRegistry schemaRegistry;
@@ -120,7 +120,7 @@ public class CassandraOnlineRetriever extends StorageRetriever implements Online
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,
       List<String> entityNames) {
 
-    List<String> columnFamilies = getColumnFamilies(featureReferences);
+    List<String> columnFamilies = getColumns(featureReferences);
     String tableName = getTableName(project, entityNames);
 
     List<ByteBuffer> rowKeys =

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.cassandra.retriever;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.querybuilder.select.Select;
+import com.datastax.oss.driver.api.querybuilder.select.Selector;
+import com.google.protobuf.ByteString;
+import feast.proto.serving.ServingAPIProto;
+import feast.proto.types.ValueProto;
+import feast.storage.api.retriever.Feature;
+import feast.storage.api.retriever.OnlineRetrieverV2;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CassandraOnlineRetriever implements OnlineRetrieverV2 {
+
+  private CqlSession session;
+  private CassandraSchemaRegistry schemaRegistry;
+
+  private static String ENTITY_KEY = "key";
+
+  public CassandraOnlineRetriever(CqlSession session) {
+    this.session = session;
+    this.schemaRegistry = new CassandraSchemaRegistry(session);
+  }
+
+  /**
+   * Generate name of Cassandra table in the form of <feastProject>__<entityNames>
+   *
+   * @param project Name of Feast project
+   * @param entityNames List of entities used in retrieval call
+   * @return Name of Cassandra table
+   */
+  private String getTableName(String project, List<String> entityNames) {
+    String tableName =
+        String.format("%s__%s", project, entityNames.stream().collect(Collectors.joining("__")));
+
+    return tableName;
+  }
+
+  /**
+   * Convert Entity value from Feast valueType to String type. Currently only supports STRING_VAL,
+   * INT64_VAL, INT32_VAL and BYTES_VAL.
+   *
+   * @param v Entity value of Feast valueType
+   * @return String representation of Entity value
+   */
+  private String valueToString(ValueProto.Value v) {
+    String stringRepr;
+    switch (v.getValCase()) {
+      case STRING_VAL:
+        stringRepr = v.getStringVal();
+        break;
+      case INT64_VAL:
+        stringRepr = String.valueOf(v.getInt64Val());
+        break;
+      case INT32_VAL:
+        stringRepr = String.valueOf(v.getInt32Val());
+        break;
+      case BYTES_VAL:
+        stringRepr = v.getBytesVal().toString();
+        break;
+      default:
+        throw new RuntimeException("Type is not supported to be entity");
+    }
+
+    return stringRepr;
+  }
+
+  /**
+   * Generate Cassandra key in the form of entity values joined by #.
+   *
+   * @param entityRow Single EntityRow representation in feature retrieval call
+   * @param entityNames List of entities related to feature references in retrieval call
+   * @return Cassandra key for retrieval
+   */
+  private ByteString convertEntityValueToCassandraKey(
+      ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow entityRow, List<String> entityNames) {
+    return ByteString.copyFrom(
+        entityNames.stream()
+            .map(entity -> entityRow.getFieldsMap().get(entity))
+            .map(this::valueToString)
+            .collect(Collectors.joining("#"))
+            .getBytes());
+  }
+
+  /**
+   * Retrieve BigTable table column families based on FeatureTable names.
+   *
+   * @param featureReferences List of feature references of features in retrieval call
+   * @return List of String of FeatureTable names
+   */
+  private List<String> getColumnFamilies(
+      List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
+    return featureReferences.stream()
+        .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<List<Feature>> getOnlineFeatures(
+      String project,
+      List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
+      List<ServingAPIProto.FeatureReferenceV2> featureReferences,
+      List<String> entityNames) {
+
+    List<String> columnFamilies = getColumnFamilies(featureReferences);
+    String tableName = getTableName(project, entityNames);
+    List<ByteString> rowKeys =
+        entityRows.stream()
+            .map(row -> convertEntityValueToCassandraKey(row, entityNames))
+            .collect(Collectors.toList());
+
+    Map<ByteString, Row> rowsFromCassandra =
+        getFeaturesFromCassandra(tableName, rowKeys, columnFamilies);
+
+    return Collections.emptyList();
+  }
+
+  /**
+   * Retrieve rows for each row entity key by generating Cassandra Query with filters based on
+   * columns.
+   *
+   * @param tableName Name of Cassandra table
+   * @param rowKeys List of keys of rows to retrieve
+   * @param columnFamilies List of FeatureTable names
+   * @return Map of retrieved features for each rowKey
+   */
+  private Map<ByteString, Row> getFeaturesFromCassandra(
+      String tableName, List<ByteString> rowKeys, List<String> columnFamilies) {
+    List<Selector> selectors =
+        columnFamilies.stream().map(cf -> Selector.column(cf)).collect(Collectors.toList());
+
+    Select query =
+        QueryBuilder.selectFrom(tableName)
+            .listOf(selectors)
+            .whereColumn(ENTITY_KEY)
+            .in(QueryBuilder.bindMarker());
+
+    SimpleStatement statement = query.build();
+
+    return Collections.emptyMap();
+  }
+}

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -248,13 +248,23 @@ public class CassandraOnlineRetriever implements OnlineRetrieverV2 {
                           ByteBuffer schemaRefKey =
                               row.getByteBuffer(featureTableColumn + SCHEMA_REF_SUFFIX);
 
+                          // Prevent retrieval of features from incorrect FeatureTable
+                          List<ServingAPIProto.FeatureReferenceV2> localFeatureReferences =
+                              featureReferences.stream()
+                                  .filter(
+                                      featureReference ->
+                                          featureReference
+                                              .getFeatureTable()
+                                              .equals(featureTableColumn))
+                                  .collect(Collectors.toList());
+
                           List<Feature> features;
                           try {
                             features =
                                 decodeFeatures(
                                     schemaRefKey,
                                     featureValues,
-                                    featureReferences,
+                                    localFeatureReferences,
                                     row.getLong(featureTableColumn + EVENT_TIMESTAMP_SUFFIX));
                           } catch (IOException e) {
                             throw new RuntimeException("Failed to decode features from Cassandra");

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -184,6 +184,10 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
       long timestamp)
       throws IOException {
 
+    if (value == null || schemaRefKey == null) {
+      return Collections.emptyList();
+    }
+
     CassandraSchemaRegistry.SchemaReference schemaReference =
         new CassandraSchemaRegistry.SchemaReference(schemaRefKey);
 

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -34,11 +34,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.avro.AvroRuntimeException;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 
 public class CassandraOnlineRetriever implements OnlineRetrieverV2 {

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraSchemaRegistry.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraSchemaRegistry.java
@@ -68,7 +68,8 @@ public class CassandraSchemaRegistry {
   public CassandraSchemaRegistry(CqlSession session) {
     this.session = session;
 
-    CacheLoader<SchemaReference, GenericDatumReader<GenericRecord>> schemaCacheLoader = CacheLoader.from(this::loadReader);
+    CacheLoader<SchemaReference, GenericDatumReader<GenericRecord>> schemaCacheLoader =
+        CacheLoader.from(this::loadReader);
 
     cache = CacheBuilder.newBuilder().build(schemaCacheLoader);
   }
@@ -95,8 +96,9 @@ public class CassandraSchemaRegistry {
 
     Row row = session.execute(statement).one();
 
-    Schema schema = new Schema.Parser()
-        .parse(StandardCharsets.UTF_8.decode(row.getByteBuffer(SCHEMA_COLUMN)).toString());
+    Schema schema =
+        new Schema.Parser()
+            .parse(StandardCharsets.UTF_8.decode(row.getByteBuffer(SCHEMA_COLUMN)).toString());
     return new GenericDatumReader<>(schema);
   }
 }

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraSchemaRegistry.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraSchemaRegistry.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.cassandra.retriever;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import org.apache.avro.Schema;
+
+public class CassandraSchemaRegistry {
+  private final CqlSession session;
+  private final LoadingCache<SchemaReference, Schema> cache;
+
+  private static String KEYSPACE = "feast";
+  private static String SCHEMA_COLUMN = "avro_schema";
+
+  public static class SchemaReference {
+    private final String tableName;
+    private final ByteString schemaHash;
+
+    public SchemaReference(String tableName, ByteString schemaHash) {
+      this.tableName = tableName;
+      this.schemaHash = schemaHash;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public ByteString getSchemaHash() {
+      return schemaHash;
+    }
+  }
+
+  public CassandraSchemaRegistry(CqlSession session) {
+    this.session = session;
+
+    CacheLoader<SchemaReference, Schema> schemaCacheLoader = CacheLoader.from(this::loadSchema);
+
+    cache = CacheBuilder.newBuilder().build(schemaCacheLoader);
+  }
+
+  public Schema getSchema(SchemaReference reference) {
+    Schema schema;
+    try {
+      schema = this.cache.get(reference);
+    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
+      throw new RuntimeException(String.format("Unable to find Schema"), e);
+    }
+    return schema;
+  }
+
+  private Schema loadSchema(SchemaReference reference) {
+    ResultSet rs =
+        session.execute(
+            String.format(
+                "SELECT %s FROM %s.%s WHERE schema_ref = '%s'",
+                SCHEMA_COLUMN,
+                KEYSPACE,
+                reference.getTableName(),
+                ByteBuffer.wrap(reference.getSchemaHash().toByteArray())));
+    Row row = rs.one();
+
+    return new Schema.Parser().parse(row.getTupleValue(SCHEMA_COLUMN).toString());
+  }
+}

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
@@ -18,24 +18,18 @@ package feast.storage.connectors.cassandra.retriever;
 
 public class CassandraStoreConfig {
 
-  private final String host;
-  private final Integer port;
+  private final String connectionString;
   private final String dataCenter;
   private final String keySpace;
 
-  public CassandraStoreConfig(String host, Integer port, String dataCenter, String keySpace) {
-    this.host = host;
-    this.port = port;
+  public CassandraStoreConfig(String connectionString, String dataCenter, String keySpace) {
+    this.connectionString = connectionString;
     this.dataCenter = dataCenter;
     this.keySpace = keySpace;
   }
 
-  public String getHost() {
-    return this.host;
-  }
-
-  public Integer getPort() {
-    return this.port;
+  public String getConnectionString() {
+    return this.connectionString;
   }
 
   public String getDataCenter() {

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.cassandra.retriever;
+
+public class CassandraStoreConfig {
+
+  private final String host;
+  private final Integer port;
+  private final String dataCenter;
+
+  public CassandraStoreConfig(String host, Integer port, String dataCenter) {
+    this.host = host;
+    this.port = port;
+    this.dataCenter = dataCenter;
+  }
+
+  public String getHost() {
+    return this.host;
+  }
+
+  public Integer getPort() {
+    return this.port;
+  }
+
+  public String getDataCenter() {
+    return this.dataCenter;
+  }
+}

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraStoreConfig.java
@@ -21,11 +21,13 @@ public class CassandraStoreConfig {
   private final String host;
   private final Integer port;
   private final String dataCenter;
+  private final String keySpace;
 
-  public CassandraStoreConfig(String host, Integer port, String dataCenter) {
+  public CassandraStoreConfig(String host, Integer port, String dataCenter, String keySpace) {
     this.host = host;
     this.port = port;
     this.dataCenter = dataCenter;
+    this.keySpace = keySpace;
   }
 
   public String getHost() {
@@ -38,5 +40,9 @@ public class CassandraStoreConfig {
 
   public String getDataCenter() {
     return this.dataCenter;
+  }
+
+  public String getKeySpace() {
+    return this.keySpace;
   }
 }

--- a/storage/connectors/pom.xml
+++ b/storage/connectors/pom.xml
@@ -18,6 +18,7 @@
         <module>redis</module>
         <module>bigtable</module>
         <module>cassandra</module>
+        <module>sstable</module>
     </modules>
 
     <build>

--- a/storage/connectors/pom.xml
+++ b/storage/connectors/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>redis</module>
         <module>bigtable</module>
+        <module>cassandra</module>
     </modules>
 
     <build>

--- a/storage/connectors/sstable/pom.xml
+++ b/storage/connectors/sstable/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>feast-storage-connectors</artifactId>
+        <groupId>dev.feast</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>feast-storage-connector-sstable</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+</project>

--- a/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
+++ b/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
@@ -14,24 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.storage.api.retriever;
+package feast.storage.connectors.sstable.retriever;
 
 import feast.proto.serving.ServingAPIProto;
 import feast.proto.types.ValueProto;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class StorageRetriever {
+public interface SSTableOnlineRetriever {
 
   /**
-   * Generate name of Cassandra table in the form of <feastProject>__<entityNames>
+   * Retrieve name of SSTable corresponding to entities in retrieval call
    *
    * @param project Name of Feast project
    * @param entityNames List of entities used in retrieval call
    * @return Name of Cassandra table
    */
-  protected String getTableName(String project, List<String> entityNames) {
-    return String.format("%s__%s", project, entityNames.stream().collect(Collectors.joining("__")));
+  default String getTableName(String project, List<String> entityNames) {
+    return String.format("%s__%s", project, String.join("__", entityNames));
   }
 
   /**
@@ -41,7 +41,7 @@ public class StorageRetriever {
    * @param v Entity value of Feast valueType
    * @return String representation of Entity value
    */
-  protected String valueToString(ValueProto.Value v) {
+  default String valueToString(ValueProto.Value v) {
     String stringRepr;
     switch (v.getValCase()) {
       case STRING_VAL:
@@ -64,13 +64,12 @@ public class StorageRetriever {
   }
 
   /**
-   * Retrieve Cassandra table column families based on FeatureTable names.
+   * Retrieve SSTable columns based on Feature references.
    *
-   * @param featureReferences List of feature references of features in retrieval call
-   * @return List of String of FeatureTable names
+   * @param featureReferences List of feature references in retrieval call
+   * @return List of String of column names
    */
-  protected List<String> getColumnFamilies(
-      List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
+  default List<String> getColumns(List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
     return featureReferences.stream()
         .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
         .distinct()

--- a/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
+++ b/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
@@ -21,7 +21,6 @@ import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow;
 import feast.proto.types.ValueProto;
 import feast.storage.api.retriever.Feature;
 import feast.storage.api.retriever.OnlineRetrieverV2;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -138,5 +137,4 @@ public interface SSTableOnlineRetriever<K, V> extends OnlineRetrieverV2 {
         .distinct()
         .collect(Collectors.toList());
   }
-
 }


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Support Cassandra store for Online Serving as alternative to Redis, Redis Cluster and BigTable
- Related Spark ingestion PR: https://github.com/feast-dev/feast-spark/pull/51

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cassandra online store is available as alternative storage to Redis, Redis Cluster and BigTable.
```