### PR TITLE
Fix SSTable name length restrictions during retrieval

### DIFF
--- a/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
@@ -158,9 +158,21 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
             .build();
     TestUtils.applyEntity(coreClient, projectName, driverEntitySpec);
 
+    // Apply Entity (this_is_a_long_long_long_long_long_long_entity_id)
+    String superLongEntityName = "this_is_a_long_long_long_long_long_long_entity_id";
+    String superLongEntityDescription = "My super long entity id";
+    ValueProto.ValueType.Enum superLongEntityType = ValueProto.ValueType.Enum.INT64;
+    EntityProto.EntitySpecV2 superLongEntitySpec =
+        EntityProto.EntitySpecV2.newBuilder()
+            .setName(superLongEntityName)
+            .setDescription(superLongEntityDescription)
+            .setValueType(superLongEntityType)
+            .build();
+    TestUtils.applyEntity(coreClient, projectName, superLongEntitySpec);
+
     // Apply Entity (merchant_id)
     String merchantEntityName = "merchant_id";
-    String merchantEntityDescription = "My driver id";
+    String merchantEntityDescription = "My merchant id";
     ValueProto.ValueType.Enum merchantEntityType = ValueProto.ValueType.Enum.INT64;
     EntityProto.EntitySpecV2 merchantEntitySpec =
         EntityProto.EntitySpecV2.newBuilder()
@@ -186,6 +198,27 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
     TestUtils.applyFeatureTable(
         coreClient, projectName, ridesFeatureTableName, ridesEntities, ridesFeatures, 7200);
 
+    // Apply FeatureTable (superLong)
+    String superLongFeatureTableName = "superlong";
+    ImmutableList<String> superLongEntities = ImmutableList.of(superLongEntityName);
+    ImmutableMap<String, ValueProto.ValueType.Enum> superLongFeatures =
+        ImmutableMap.of(
+            "trip_cost",
+            ValueProto.ValueType.Enum.INT64,
+            "trip_distance",
+            ValueProto.ValueType.Enum.DOUBLE,
+            "trip_empty",
+            ValueProto.ValueType.Enum.DOUBLE,
+            "trip_wrong_type",
+            ValueProto.ValueType.Enum.STRING);
+    TestUtils.applyFeatureTable(
+        coreClient,
+        projectName,
+        superLongFeatureTableName,
+        superLongEntities,
+        superLongFeatures,
+        7200);
+
     // Apply FeatureTable (rides_merchant)
     String rideMerchantFeatureTableName = "rides_merchant";
     ImmutableList<String> ridesMerchantEntities =
@@ -199,6 +232,8 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
         7200);
 
     // BigTable Table names
+    String superLongBtTableName = String.format("%s__%s", projectName, superLongEntityName);
+    superLongBtTableName = trimAndHash(superLongBtTableName, 50);
     String btTableName = String.format("%s__%s", projectName, driverEntityName);
     String compoundBtTableName =
         String.format(
@@ -236,6 +271,39 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
     byte[] schemaKey = createSchemaKey(schemaReference);
     ingestData(
         featureTableName, btTableName, entityFeatureKey, entityFeatureValue, schemaKey, ftSchema);
+
+    /** SuperLong Entity Ingestion Workflow */
+    Schema superLongFtSchema =
+        SchemaBuilder.record("SuperLongData")
+            .namespace(superLongFeatureTableName)
+            .fields()
+            .requiredLong(feature1Reference.getName())
+            .requiredDouble(feature2Reference.getName())
+            .nullableString(feature3Reference.getName(), "null")
+            .requiredString(feature4Reference.getName())
+            .endRecord();
+    byte[] superLongSchemaReference =
+        Hashing.murmur3_32().hashBytes(superLongFtSchema.toString().getBytes()).asBytes();
+
+    GenericRecord superLongRecord =
+        new GenericRecordBuilder(superLongFtSchema)
+            .set("trip_cost", 5L)
+            .set("trip_distance", 3.5)
+            .set("trip_empty", null)
+            .set("trip_wrong_type", "test")
+            .build();
+    byte[] superLongEntityFeatureKey =
+        String.valueOf(DataGenerator.createInt64Value(1).getInt64Val()).getBytes();
+    byte[] superLongEntityFeatureValue =
+        createEntityValue(superLongFtSchema, superLongSchemaReference, superLongRecord);
+    byte[] superLongSchemaKey = createSchemaKey(superLongSchemaReference);
+    ingestData(
+        superLongFeatureTableName,
+        superLongBtTableName,
+        superLongEntityFeatureKey,
+        superLongEntityFeatureValue,
+        superLongSchemaKey,
+        superLongFtSchema);
 
     /** Compound Entity Ingestion Workflow */
     Schema compoundFtSchema =
@@ -397,6 +465,17 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
     encoder.flush();
 
     return output.toByteArray();
+  }
+
+  private static String trimAndHash(String expr, int maxLength) {
+    int maxPrefixLength = 40;
+    String finalName = expr;
+    if (expr.length() > maxLength) {
+      String hashSuffix =
+          Hashing.murmur3_32().hashBytes(expr.substring(maxPrefixLength).getBytes()).toString();
+      finalName = expr.substring(0, Math.min(expr.length(), maxLength)).concat(hashSuffix);
+    }
+    return finalName;
   }
 
   @Test
@@ -724,6 +803,62 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
 
     assert featureResponse.getFieldValues(0).getStatusesMap().values().stream()
         .allMatch(status -> status.equals(GetOnlineFeaturesResponse.FieldStatus.PRESENT));
+  }
+
+  @Test
+  public void shouldRegisterSuperLongEntityAndGetOnlineFeatures() {
+    // getOnlineFeatures Information
+    String projectName = "default";
+    String entityName = "this_is_a_long_long_long_long_long_long_entity_id";
+    ValueProto.Value entityValue = ValueProto.Value.newBuilder().setInt64Val(1).build();
+
+    // Instantiate EntityRows
+    GetOnlineFeaturesRequestV2.EntityRow entityRow1 =
+        DataGenerator.createEntityRow(entityName, DataGenerator.createInt64Value(1), 100);
+    ImmutableList<GetOnlineFeaturesRequestV2.EntityRow> entityRows = ImmutableList.of(entityRow1);
+
+    // Instantiate FeatureReferences
+    FeatureReferenceV2 featureReference =
+        DataGenerator.createFeatureReference("superlong", "trip_cost");
+    FeatureReferenceV2 notFoundFeatureReference =
+        DataGenerator.createFeatureReference("superlong", "trip_transaction");
+
+    ImmutableList<FeatureReferenceV2> featureReferences =
+        ImmutableList.of(featureReference, notFoundFeatureReference);
+
+    // Build GetOnlineFeaturesRequestV2
+    GetOnlineFeaturesRequestV2 onlineFeatureRequest =
+        TestUtils.createOnlineFeatureRequest(projectName, featureReferences, entityRows);
+    GetOnlineFeaturesResponse featureResponse =
+        servingStub.getOnlineFeaturesV2(onlineFeatureRequest);
+
+    ImmutableMap<String, ValueProto.Value> expectedValueMap =
+        ImmutableMap.of(
+            entityName,
+            entityValue,
+            FeatureV2.getFeatureStringRef(featureReference),
+            DataGenerator.createInt64Value(5),
+            FeatureV2.getFeatureStringRef(notFoundFeatureReference),
+            DataGenerator.createEmptyValue());
+
+    ImmutableMap<String, GetOnlineFeaturesResponse.FieldStatus> expectedStatusMap =
+        ImmutableMap.of(
+            entityName,
+            GetOnlineFeaturesResponse.FieldStatus.PRESENT,
+            FeatureV2.getFeatureStringRef(featureReference),
+            GetOnlineFeaturesResponse.FieldStatus.PRESENT,
+            FeatureV2.getFeatureStringRef(notFoundFeatureReference),
+            GetOnlineFeaturesResponse.FieldStatus.NOT_FOUND);
+
+    GetOnlineFeaturesResponse.FieldValues expectedFieldValues =
+        GetOnlineFeaturesResponse.FieldValues.newBuilder()
+            .putAllFields(expectedValueMap)
+            .putAllStatuses(expectedStatusMap)
+            .build();
+    ImmutableList<GetOnlineFeaturesResponse.FieldValues> expectedFieldValuesList =
+        ImmutableList.of(expectedFieldValues);
+
+    assertEquals(expectedFieldValuesList, featureResponse.getFieldValuesList());
   }
 
   @TestConfiguration

--- a/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
@@ -468,12 +468,12 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
   }
 
   private static String trimAndHash(String expr, int maxLength) {
-    int maxPrefixLength = 40;
+    int maxPrefixLength = maxLength - 8;
     String finalName = expr;
     if (expr.length() > maxLength) {
       String hashSuffix =
           Hashing.murmur3_32().hashBytes(expr.substring(maxPrefixLength).getBytes()).toString();
-      finalName = expr.substring(0, Math.min(expr.length(), maxLength)).concat(hashSuffix);
+      finalName = expr.substring(0, Math.min(expr.length(), maxPrefixLength)).concat(hashSuffix);
     }
     return finalName;
   }

--- a/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
@@ -233,7 +233,12 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
 
     // BigTable Table names
     String superLongBtTableName = String.format("%s__%s", projectName, superLongEntityName);
-    superLongBtTableName = trimAndHash(superLongBtTableName, 50);
+    String hashSuffix =
+        Hashing.murmur3_32().hashBytes(superLongBtTableName.substring(42).getBytes()).toString();
+    superLongBtTableName =
+        superLongBtTableName
+            .substring(0, Math.min(superLongBtTableName.length(), 42))
+            .concat(hashSuffix);
     String btTableName = String.format("%s__%s", projectName, driverEntityName);
     String compoundBtTableName =
         String.format(
@@ -465,17 +470,6 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
     encoder.flush();
 
     return output.toByteArray();
-  }
-
-  private static String trimAndHash(String expr, int maxLength) {
-    int maxPrefixLength = maxLength - 8;
-    String finalName = expr;
-    if (expr.length() > maxLength) {
-      String hashSuffix =
-          Hashing.murmur3_32().hashBytes(expr.substring(maxPrefixLength).getBytes()).toString();
-      finalName = expr.substring(0, Math.min(expr.length(), maxPrefixLength)).concat(hashSuffix);
-    }
-    return finalName;
   }
 
   @Test

--- a/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
+++ b/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
@@ -42,6 +42,7 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
 
   private BigtableDataClient client;
   private BigTableSchemaRegistry schemaRegistry;
+  private static final int MAX_TABLE_NAME_LENGTH = 50;
 
   public BigTableOnlineRetriever(BigtableDataClient client) {
     this.client = client;
@@ -63,6 +64,19 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
             .map(this::valueToString)
             .collect(Collectors.joining("#"))
             .getBytes());
+  }
+
+  /**
+   * Generate BigTable table name, with limit of 50 characters.
+   *
+   * @param project Name of Feast project
+   * @param entityNames List of entities used in retrieval call
+   * @return BigTable table name for retrieval
+   */
+  @Override
+  public String getSSTable(String project, List<String> entityNames) {
+    String tableName = String.format("%s__%s", project, String.join("__", entityNames));
+    return tableName.substring(0, Math.min(tableName.length(), MAX_TABLE_NAME_LENGTH));
   }
 
   /**

--- a/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
+++ b/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableOnlineRetriever.java
@@ -42,7 +42,6 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
 
   private BigtableDataClient client;
   private BigTableSchemaRegistry schemaRegistry;
-  private static final int MAX_TABLE_NAME_LENGTH = 50;
 
   public BigTableOnlineRetriever(BigtableDataClient client) {
     this.client = client;
@@ -64,19 +63,6 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
             .map(this::valueToString)
             .collect(Collectors.joining("#"))
             .getBytes());
-  }
-
-  /**
-   * Generate BigTable table name, with limit of 50 characters.
-   *
-   * @param project Name of Feast project
-   * @param entityNames List of entities used in retrieval call
-   * @return BigTable table name for retrieval
-   */
-  @Override
-  public String getSSTable(String project, List<String> entityNames) {
-    String tableName = String.format("%s__%s", project, String.join("__", entityNames));
-    return tableName.substring(0, Math.min(tableName.length(), MAX_TABLE_NAME_LENGTH));
   }
 
   /**

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -51,6 +51,7 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
   private static final String ENTITY_KEY = "key";
   private static final String SCHEMA_REF_SUFFIX = "__schema_ref";
   private static final String EVENT_TIMESTAMP_SUFFIX = "__event_timestamp";
+  private static final int MAX_TABLE_NAME_LENGTH = 48;
 
   public CassandraOnlineRetriever(CqlSession session) {
     this.session = session;
@@ -72,6 +73,19 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
             .map(this::valueToString)
             .collect(Collectors.joining("#"))
             .getBytes());
+  }
+
+  /**
+   * Generate Cassandra table name, with limit of 48 characters.
+   *
+   * @param project Name of Feast project
+   * @param entityNames List of entities used in retrieval call
+   * @return Cassandra table name for retrieval
+   */
+  @Override
+  public String getSSTable(String project, List<String> entityNames) {
+    String tableName = String.format("%s__%s", project, String.join("__", entityNames));
+    return tableName.substring(0, Math.min(tableName.length(), MAX_TABLE_NAME_LENGTH));
   }
 
   /**

--- a/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
+++ b/storage/connectors/cassandra/src/main/java/feast/storage/connectors/cassandra/retriever/CassandraOnlineRetriever.java
@@ -85,7 +85,7 @@ public class CassandraOnlineRetriever implements SSTableOnlineRetriever<ByteBuff
   @Override
   public String getSSTable(String project, List<String> entityNames) {
     String tableName = String.format("%s__%s", project, String.join("__", entityNames));
-    return tableName.substring(0, Math.min(tableName.length(), MAX_TABLE_NAME_LENGTH));
+    return trimAndHash(tableName, MAX_TABLE_NAME_LENGTH);
   }
 
   /**

--- a/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
+++ b/storage/connectors/sstable/src/main/java/feast/storage/connectors/sstable/retriever/SSTableOnlineRetriever.java
@@ -150,12 +150,13 @@ public interface SSTableOnlineRetriever<K, V> extends OnlineRetrieverV2 {
    * @return Hashed suffix SSTable table name
    */
   default String trimAndHash(String expr, int maxLength) {
-    int maxPrefixLength = 40;
+    // Length 8 as derived from murmurhash_32 implementation
+    int maxPrefixLength = maxLength - 8;
     String finalName = expr;
     if (expr.length() > maxLength) {
       String hashSuffix =
           Hashing.murmur3_32().hashBytes(expr.substring(maxPrefixLength).getBytes()).toString();
-      finalName = expr.substring(0, Math.min(expr.length(), maxLength)).concat(hashSuffix);
+      finalName = expr.substring(0, Math.min(expr.length(), maxPrefixLength)).concat(hashSuffix);
     }
     return finalName;
   }


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR fixes retrieval failure when table name length exceeds limit:
- 50 Characters (BigTable): [Docs](https://cloud.google.com/bigtable/quotas)
- 48 Characters (Cassandra): [Docs](https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/refLimits.html#:~:text=Table%20%2F%20CF%20name%20length%3A%2048,65535%20(2%2016%2D1))

[Relevant PR at `feast-spark` repository that addresses this issue during ingestion](https://github.com/feast-dev/feast-spark/pull/70).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```