### PR TITLE
Allow Bigtable appProfileId to be configurable

### DIFF
--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -314,7 +314,10 @@ public class FeastProperties {
     }
 
     public BigTableStoreConfig getBigtableConfig() {
-      return new BigTableStoreConfig(this.config.get("project_id"), this.config.get("instance_id"));
+      return new BigTableStoreConfig(
+          this.config.get("project_id"),
+          this.config.get("instance_id"),
+          this.config.get("app_profile_id"));
     }
 
     public CassandraStoreConfig getCassandraConfig() {

--- a/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
+++ b/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
@@ -59,6 +59,7 @@ public class ServingServiceConfigV2 {
         BigtableDataSettings.newBuilder()
             .setProjectId(projectId)
             .setInstanceId(instanceId)
+            .setAppProfileId(config.getAppProfileId())
             .build());
   }
 

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -59,6 +59,7 @@ feast:
       config:
         project_id: <gcp_project>
         instance_id: <gcp_bigtable_instance>
+        app_profile_id: <gcp_bigtable_app_profile_id>
     - name: cassandra
       type: CASSANDRA
       config:

--- a/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceBigTableIT.java
@@ -96,6 +96,7 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
 
   static final String PROJECT_ID = "test-project";
   static final String INSTANCE_ID = "test-instance";
+  static final String APP_PROFILE_ID = "default";
   static ManagedChannel channel;
 
   static final FeatureReferenceV2 feature1Reference =
@@ -865,6 +866,7 @@ public class ServingServiceBigTableIT extends BaseAuthIT {
                   environment.getServicePort("bigtable_1", BIGTABLE_PORT))
               .setProjectId(PROJECT_ID)
               .setInstanceId(INSTANCE_ID)
+              .setAppProfileId(APP_PROFILE_ID)
               .build());
     }
   }

--- a/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableStoreConfig.java
+++ b/storage/connectors/bigtable/src/main/java/feast/storage/connectors/bigtable/retriever/BigTableStoreConfig.java
@@ -19,10 +19,12 @@ package feast.storage.connectors.bigtable.retriever;
 public class BigTableStoreConfig {
   private final String projectId;
   private final String instanceId;
+  private final String appProfileId;
 
-  public BigTableStoreConfig(String projectId, String instanceId) {
+  public BigTableStoreConfig(String projectId, String instanceId, String appProfileId) {
     this.projectId = projectId;
     this.instanceId = instanceId;
+    this.appProfileId = appProfileId;
   }
 
   public String getProjectId() {
@@ -31,5 +33,9 @@ public class BigTableStoreConfig {
 
   public String getInstanceId() {
     return this.instanceId;
+  }
+
+  public String getAppProfileId() {
+    return this.appProfileId;
   }
 }


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds configuration of `appProfileId` for BigTable. This would allow users to specify different app profiles for serving and ingestion. An example of a use-case would be separating reads and writes for different app profiles.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can configure Bigtable app profiles for Feast Serving
```