### PR TITLE
Add project label to latency metric

### DIFF
--- a/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -25,6 +25,7 @@ import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.proto.serving.ServingServiceGrpc.ServingServiceImplBase;
 import feast.serving.config.FeastProperties;
 import feast.serving.exception.SpecRetrievalException;
+import feast.serving.interceptors.GrpcMonitoringContext;
 import feast.serving.interceptors.GrpcMonitoringInterceptor;
 import feast.serving.service.ServingServiceV2;
 import feast.serving.util.RequestHelper;
@@ -86,6 +87,9 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
         // project set at root level overrides the project set at feature table level
         this.authorizationService.authorizeRequest(
             SecurityContextHolder.getContext(), request.getProject());
+
+        // update monitoring context
+        GrpcMonitoringContext.getInstance().setProject(request.getProject());
       }
       RequestHelper.validateOnlineRequest(request);
       Span span = tracer.buildSpan("getOnlineFeaturesV2").start();

--- a/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringContext.java
+++ b/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringContext.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.interceptors;
+
+import java.util.Optional;
+
+public class GrpcMonitoringContext {
+  private static GrpcMonitoringContext INSTANCE;
+
+  final ThreadLocal<String> project = new ThreadLocal();
+
+  private GrpcMonitoringContext() {}
+
+  public static GrpcMonitoringContext getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new GrpcMonitoringContext();
+    }
+
+    return INSTANCE;
+  }
+
+  public void setProject(String name) {
+    this.project.set(name);
+  }
+
+  public Optional<String> getProject() {
+    return Optional.ofNullable(this.project.get());
+  }
+
+  public void clearProject() {
+    this.project.set(null);
+  }
+}

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -26,7 +26,7 @@ public class Metrics {
           .name("request_latency_seconds")
           .subsystem("feast_serving")
           .help("Request latency in seconds")
-          .labelNames("method")
+          .labelNames("method", "project")
           .register();
 
   public static final Histogram requestEntityCountDistribution =


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

To be able to observer latency of online serving by project this PR adds project label to latency metric.