### PR TITLE
Port feast 0.10+ data model to feast-serving

### DIFF
--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -72,6 +72,16 @@ public class FeastProperties {
   /* Feast Core port to connect to. */
   @Positive private int coreGrpcPort;
 
+  private String registry;
+
+  public String getRegistry() {
+    return registry;
+  }
+
+  public void setRegistry(final String registry) {
+    this.registry = registry;
+  }
+
   private CoreAuthenticationProperties coreAuthentication;
 
   public CoreAuthenticationProperties getCoreAuthentication() {
@@ -82,7 +92,6 @@ public class FeastProperties {
     this.coreAuthentication = coreAuthentication;
   }
 
-  /* Feast Core port to connect to. */
   @Positive private int coreCacheRefreshInterval;
 
   private SecurityProperties security;

--- a/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
+++ b/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -45,6 +46,7 @@ public class SpecServiceConfig {
     this.feastCachedSpecServiceRefreshInterval = feastProperties.getCoreCacheRefreshInterval();
   }
 
+  @ConditionalOnProperty(name = "feast.registry", matchIfMissing = true)
   @Bean
   public ScheduledExecutorService cachedSpecServiceScheduledExecutorService(
       CachedSpecService cachedSpecStorage) {
@@ -59,6 +61,7 @@ public class SpecServiceConfig {
     return scheduledExecutorService;
   }
 
+  @ConditionalOnProperty(name = "feast.registry", matchIfMissing = true)
   @Bean
   public CachedSpecService specService(ObjectProvider<CallCredentials> callCredentials)
       throws InvalidProtocolBufferException, JsonProcessingException {

--- a/serving/src/main/java/feast/serving/registry/LocalRegistryRepo.java
+++ b/serving/src/main/java/feast/serving/registry/LocalRegistryRepo.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.registry;
+
+import feast.proto.core.FeatureProto;
+import feast.proto.core.FeatureViewProto;
+import feast.proto.core.RegistryProto;
+import feast.proto.serving.ServingAPIProto;
+import feast.serving.exception.SpecRetrievalException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LocalRegistryRepo implements RegistryRepository {
+
+  private final Path localRegistryPath;
+
+  public LocalRegistryRepo(Path localRegistryPath) {
+    this.localRegistryPath = localRegistryPath;
+  }
+
+  @Override
+  public RegistryProto.Registry getRegistry() {
+    try {
+      final byte[] registryContents = Files.readAllBytes(this.localRegistryPath);
+
+      return RegistryProto.Registry.parseFrom(registryContents);
+
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public FeatureViewProto.FeatureViewSpec getFeatureViewSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    final RegistryProto.Registry registry = this.getRegistry();
+    for (final FeatureViewProto.FeatureView featureView : registry.getFeatureViewsList()) {
+      if (featureView.getSpec().getName().equals(featureReference.getFeatureTable())) {
+        return featureView.getSpec();
+      }
+    }
+    throw new SpecRetrievalException(
+        String.format(
+            "Unable to find feature view with name: %s", featureReference.getFeatureTable()));
+  }
+
+  @Override
+  public FeatureProto.FeatureSpecV2 getFeatureSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    final FeatureViewProto.FeatureViewSpec spec =
+        this.getFeatureViewSpec(projectName, featureReference);
+    for (final FeatureProto.FeatureSpecV2 featureSpec : spec.getFeaturesList()) {
+      if (featureSpec.getName().equals(featureReference.getName())) {
+        return featureSpec;
+      }
+    }
+
+    throw new SpecRetrievalException(
+        String.format(
+            "Unable to find feature with name: %s in feature view: %s",
+            featureReference.getName(), featureReference.getFeatureTable()));
+  }
+}

--- a/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.registry;
+
+import feast.proto.core.FeatureProto;
+import feast.proto.core.FeatureViewProto;
+import feast.proto.core.RegistryProto;
+import feast.proto.serving.ServingAPIProto;
+
+public interface RegistryRepository {
+  RegistryProto.Registry getRegistry();
+
+  FeatureViewProto.FeatureViewSpec getFeatureViewSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference);
+
+  FeatureProto.FeatureSpecV2 getFeatureSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference);
+}

--- a/serving/src/main/java/feast/serving/specs/CoreFeatureSpecRetriever.java
+++ b/serving/src/main/java/feast/serving/specs/CoreFeatureSpecRetriever.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.specs;
+
+import com.google.protobuf.Duration;
+import feast.proto.core.FeatureProto;
+import feast.proto.serving.ServingAPIProto;
+import java.util.List;
+
+public class CoreFeatureSpecRetriever implements FeatureSpecRetriever {
+  private final CachedSpecService specService;
+
+  public CoreFeatureSpecRetriever(CachedSpecService specService) {
+    this.specService = specService;
+  }
+
+  @Override
+  public Duration getMaxAge(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    return this.specService.getFeatureTableSpec(projectName, featureReference).getMaxAge();
+  }
+
+  @Override
+  public List<String> getEntitiesList(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    return this.specService.getFeatureTableSpec(projectName, featureReference).getEntitiesList();
+  }
+
+  @Override
+  public FeatureProto.FeatureSpecV2 getFeatureSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    return this.specService.getFeatureSpec(projectName, featureReference);
+  }
+}

--- a/serving/src/main/java/feast/serving/specs/FeatureSpecRetriever.java
+++ b/serving/src/main/java/feast/serving/specs/FeatureSpecRetriever.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.specs;
+
+import com.google.protobuf.Duration;
+import feast.proto.core.FeatureProto;
+import feast.proto.serving.ServingAPIProto;
+import java.util.List;
+
+public interface FeatureSpecRetriever {
+
+  Duration getMaxAge(String projectName, ServingAPIProto.FeatureReferenceV2 featureReference);
+
+  List<String> getEntitiesList(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference);
+
+  FeatureProto.FeatureSpecV2 getFeatureSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference);
+}

--- a/serving/src/main/java/feast/serving/specs/RegistryFeatureSpecRetriever.java
+++ b/serving/src/main/java/feast/serving/specs/RegistryFeatureSpecRetriever.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.specs;
+
+import com.google.protobuf.Duration;
+import feast.proto.core.FeatureProto;
+import feast.proto.core.FeatureViewProto;
+import feast.proto.core.RegistryProto;
+import feast.proto.serving.ServingAPIProto;
+import feast.serving.exception.SpecRetrievalException;
+import feast.serving.registry.RegistryRepository;
+import java.util.List;
+
+public class RegistryFeatureSpecRetriever implements FeatureSpecRetriever {
+  private final RegistryRepository registryRepository;
+
+  public RegistryFeatureSpecRetriever(RegistryRepository registryRepository) {
+    this.registryRepository = registryRepository;
+  }
+
+  @Override
+  public Duration getMaxAge(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    final RegistryProto.Registry registry = this.registryRepository.getRegistry();
+    for (final FeatureViewProto.FeatureView featureView : registry.getFeatureViewsList()) {
+      if (featureView.getSpec().getName().equals(featureReference.getFeatureTable())) {
+        return featureView.getSpec().getTtl();
+      }
+    }
+    throw new SpecRetrievalException(
+        String.format(
+            "Unable to find feature view with name: %s", featureReference.getFeatureTable()));
+  }
+
+  @Override
+  public List<String> getEntitiesList(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    final RegistryProto.Registry registry = this.registryRepository.getRegistry();
+    for (final FeatureViewProto.FeatureView featureView : registry.getFeatureViewsList()) {
+      if (featureView.getSpec().getName().equals(featureReference.getFeatureTable())) {
+        return featureView.getSpec().getEntitiesList();
+      }
+    }
+    throw new SpecRetrievalException(
+        String.format(
+            "Unable to find feature view with name: %s", featureReference.getFeatureTable()));
+  }
+
+  @Override
+  public FeatureProto.FeatureSpecV2 getFeatureSpec(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    return this.registryRepository.getFeatureSpec(projectName, featureReference);
+  }
+}

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -3,7 +3,9 @@ feast:
   # Feast Serving requires connection to Feast Core to retrieve and reload Feast metadata (e.g. FeatureSpecs, Store information)
   core-host: ${FEAST_CORE_HOST:localhost}
   core-grpc-port: ${FEAST_CORE_GRPC_PORT:6565}
-  
+
+  registry: "/Users/achal/tecton/feast/prompt_dory/data/registry.db"
+
   core-authentication:
     enabled: false # should be set to true if authentication is enabled on core.
     provider: google # can be set to `oauth` or `google`

--- a/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -61,7 +61,8 @@ public class OnlineServingServiceTest {
   @Before
   public void setUp() {
     initMocks(this);
-    onlineServingServiceV2 = new OnlineServingServiceV2(retrieverV2, specService, tracer);
+    onlineServingServiceV2 =
+        new OnlineServingServiceV2(retrieverV2, specService, tracer, featureSpecRetriever);
 
     mockedFeatureRows = new ArrayList<>();
     mockedFeatureRows.add(

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
@@ -39,7 +39,7 @@ public class RedisHashDecoder {
    */
   public static List<Feature> retrieveFeature(
       List<KeyValue<byte[], byte[]>> redisHashValues,
-      Map<String, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap,
+      Map<byte[], ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap,
       String timestampPrefix)
       throws InvalidProtocolBufferException {
     List<Feature> allFeatures = new ArrayList<>();
@@ -57,7 +57,7 @@ public class RedisHashDecoder {
           featureTableTimestampMap.put(new String(redisValueK), eventTimestamp);
         } else {
           ServingAPIProto.FeatureReferenceV2 featureReference =
-              byteToFeatureReferenceMap.get(redisValueK.toString());
+              byteToFeatureReferenceMap.get(redisValueK);
           ValueProto.Value featureValue = ValueProto.Value.parseFrom(redisValueV);
 
           featureMap.put(featureReference, featureValue);

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/EntityKeySerializer.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/EntityKeySerializer.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.retriever;
+
+import feast.proto.storage.RedisProto;
+
+@FunctionalInterface
+public interface EntityKeySerializer {
+  byte[] serialize(final RedisProto.RedisKeyV2 entityKey);
+}

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/EntityKeySerializerV2.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/EntityKeySerializerV2.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.retriever;
+
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.ProtocolStringList;
+import feast.proto.storage.RedisProto;
+import feast.proto.types.ValueProto;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class EntityKeySerializerV2 implements EntityKeySerializer {
+  @Override
+  public byte[] serialize(RedisProto.RedisKeyV2 entityKey) {
+    final ProtocolStringList joinKeys = entityKey.getEntityNamesList();
+    final List<ValueProto.Value> values = entityKey.getEntityValuesList();
+
+    assert joinKeys.size() == values.size();
+
+    final List<Byte> buffer = new ArrayList<>();
+
+    final List<Pair<String, ValueProto.Value>> tuples = new ArrayList<>(joinKeys.size());
+    for (int i = 0; i < joinKeys.size(); i++) {
+      tuples.add(Pair.of(joinKeys.get(i), values.get(i)));
+    }
+    tuples.sort(Comparator.comparing(Pair::getLeft));
+    for (Pair<String, ValueProto.Value> pair : tuples) {
+      for (final byte b : pair.getLeft().getBytes(StandardCharsets.UTF_8)) {
+        buffer.add(b);
+      }
+    }
+
+    for (Pair<String, ValueProto.Value> pair : tuples) {
+      final ValueProto.Value val = pair.getRight();
+      switch (val.getValCase()) {
+        case STRING_VAL:
+          buffer.add(UnsignedBytes.checkedCast(ValueProto.ValueType.Enum.STRING.getNumber()));
+          buffer.add(
+              UnsignedBytes.checkedCast(
+                  val.getStringVal().getBytes(StandardCharsets.UTF_8).length));
+          for (final byte b : val.getStringVal().getBytes(StandardCharsets.UTF_8)) {
+            buffer.add(b);
+          }
+          break;
+        case BYTES_VAL:
+        case INT32_VAL:
+        case INT64_VAL:
+          break;
+        default:
+          break;
+      }
+    }
+    for (final byte b : entityKey.getProject().getBytes(StandardCharsets.UTF_8)) {
+      buffer.add(b);
+    }
+
+    final byte[] bytes = new byte[buffer.size()];
+    for (int i = 0; i < buffer.size(); i++) {
+      bytes[i] = buffer.get(i);
+    }
+
+    return bytes;
+  }
+}


### PR DESCRIPTION
This is an initial stab as porting the new data model to feast-serving in a backwards compatible way. 

If a `registry` location is specified in the `application,.yml` that implies that feast-serving should use the new data model (feature views and the registry proto instead of the SpecService). 

Currently, this has only been tested on the Redis online store. Also, in this version of the PR only local registry files are supported.

Additionally - some work is needed to disable creation of SpecService beans to prevent log spam and conserve resources.
