### PR TITLE
Add Core's functionalities to the Java SDK

### DIFF
--- a/sdk/java/src/main/java/com/gojek/feast/GrpcManager.java
+++ b/sdk/java/src/main/java/com/gojek/feast/GrpcManager.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast;
+
+import io.grpc.CallCredentials;
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.opentracing.contrib.grpc.TracingClientInterceptor;
+import io.opentracing.util.GlobalTracer;
+import java.io.File;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLException;
+
+public abstract class GrpcManager<S extends io.grpc.stub.AbstractBlockingStub<S>>
+    implements AutoCloseable {
+
+  private static final int CHANNEL_SHUTDOWN_TIMEOUT_SEC = 5;
+
+  private final ManagedChannel channel;
+  protected final S stub;
+
+  protected GrpcManager(String host, int port, SecurityConfig securityConfig) {
+    this(createSecureChannel(host, port, securityConfig), securityConfig.getCredentials());
+  }
+
+  protected abstract S getStub(Channel channel);
+
+  protected GrpcManager(ManagedChannel channel, Optional<CallCredentials> credentials) {
+    this.channel = channel;
+    TracingClientInterceptor tracingInterceptor =
+        TracingClientInterceptor.newBuilder().withTracer(GlobalTracer.get()).build();
+
+    S servingStub = getStub(tracingInterceptor.intercept(channel));
+
+    if (credentials.isPresent()) {
+      servingStub = servingStub.withCallCredentials(credentials.get());
+    }
+
+    this.stub = servingStub;
+  }
+
+  private static ManagedChannel createSecureChannel(
+      String host, int port, SecurityConfig securityConfig) {
+    ManagedChannel channel;
+    if (securityConfig.isTLSEnabled()) {
+      if (securityConfig.getCertificatePath().isPresent()) {
+        String certificatePath = securityConfig.getCertificatePath().get();
+        // Use custom certificate for TLS
+        File certificateFile = new File(certificatePath);
+        try {
+          channel =
+              NettyChannelBuilder.forAddress(host, port)
+                  .useTransportSecurity()
+                  .sslContext(GrpcSslContexts.forClient().trustManager(certificateFile).build())
+                  .build();
+        } catch (SSLException e) {
+          throw new IllegalArgumentException(
+              String.format("Invalid Certificate provided at path: %s", certificatePath), e);
+        }
+      } else {
+        // Use system certificates for TLS
+        channel = ManagedChannelBuilder.forAddress(host, port).useTransportSecurity().build();
+      }
+    } else {
+      // Disable TLS
+      channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+    }
+    return channel;
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (channel != null) {
+      channel.shutdown().awaitTermination(CHANNEL_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
@@ -107,7 +107,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
     CoreServiceProto.GetEntityRequest.Builder request =
         CoreServiceProto.GetEntityRequest.newBuilder().setProject(project).setName(name);
     CoreServiceProto.GetEntityResponse response = stub.getEntity(request.build());
-    Entity entity = response.hasEntity() ? new Entity(response.getEntity()) : null;
+    Entity entity = response.hasEntity() ? new Entity(project, response.getEntity()) : null;
     return Optional.ofNullable(entity);
   }
 
@@ -124,7 +124,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
             .setProject(entitySpec.getProject())
             .setSpec(entitySpec.toProto());
     CoreServiceProto.ApplyEntityResponse response = stub.applyEntity(request.build());
-    Entity entity = response.hasEntity() ? new Entity(response.getEntity()) : null;
+    Entity entity = response.hasEntity() ? new Entity(entitySpec.getProject(), response.getEntity()) : null;
     return Optional.ofNullable(entity);
   }
 
@@ -153,7 +153,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
     CoreServiceProto.ListEntitiesRequest request =
         CoreServiceProto.ListEntitiesRequest.newBuilder().setFilter(filter).build();
     List<EntityProto.Entity> entities = stub.listEntities(request).getEntitiesList();
-    return entities.stream().map(Entity::new).collect(Collectors.toList());
+    return entities.stream().map(proto -> new Entity(project, proto)).collect(Collectors.toList());
   }
 
   /**
@@ -167,7 +167,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
     CoreServiceProto.GetFeatureTableRequest.Builder request =
         CoreServiceProto.GetFeatureTableRequest.newBuilder().setProject(project).setName(name);
     CoreServiceProto.GetFeatureTableResponse response = stub.getFeatureTable(request.build());
-    FeatureTable featureTable = response.hasTable() ? new FeatureTable(response.getTable()) : null;
+    FeatureTable featureTable = response.hasTable() ? new FeatureTable(project, response.getTable()) : null;
     return Optional.ofNullable(featureTable);
   }
 
@@ -184,7 +184,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
             .setProject(featureTableSpec.getProject())
             .setTableSpec(featureTableSpec.toProto());
     CoreServiceProto.ApplyFeatureTableResponse response = stub.applyFeatureTable(request.build());
-    FeatureTable featureTable = response.hasTable() ? new FeatureTable(response.getTable()) : null;
+    FeatureTable featureTable = response.hasTable() ? new FeatureTable(featureTableSpec.getProject(), response.getTable()) : null;
     return Optional.ofNullable(featureTable);
   }
 
@@ -213,7 +213,7 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
         CoreServiceProto.ListFeatureTablesRequest.newBuilder().setFilter(filter).build();
     List<FeatureTableProto.FeatureTable> featureTables =
         stub.listFeatureTables(request).getTablesList();
-    return featureTables.stream().map(FeatureTable::new).collect(Collectors.toList());
+    return featureTables.stream().map(proto -> new FeatureTable(project, proto)).collect(Collectors.toList());
   }
 
   /**

--- a/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import com.gojek.feast.GrpcManager;
+import com.gojek.feast.SecurityConfig;
+import feast.proto.core.*;
+import feast.proto.core.CoreServiceGrpc.CoreServiceBlockingStub;
+import io.grpc.CallCredentials;
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
+
+  /**
+   * Create a client to access Feast Core.
+   *
+   * @param host hostname or ip address of Feast core GRPC server
+   * @param port port number of Feast core GRPC server
+   * @return {@link CoreClient}
+   */
+  public static CoreClient create(String host, int port) {
+    // configure client with no security config.
+    return CoreClient.createSecure(host, port, SecurityConfig.newBuilder().build());
+  }
+
+  /**
+   * Create an authenticated client that can access Feast core with authentication enabled. Supports
+   * the {@link CallCredentials} in the {@link feast.common.auth.credentials} package.
+   *
+   * @param host hostname or ip address of Feast core GRPC server
+   * @param port port number of Feast core GRPC server
+   * @param securityConfig security options to configure the Feast client. See {@link
+   *     SecurityConfig} for options.
+   * @return Optional of {@link CoreClient}
+   */
+  public static CoreClient createSecure(String host, int port, SecurityConfig securityConfig) {
+    return new CoreClient(host, port, securityConfig);
+  }
+
+  /**
+   * Create a globally unique namespace to store Feature Tables in.
+   *
+   * @param name of the project.
+   * @return true if request returned, false otherwise.
+   */
+  public boolean createProject(String name) {
+    CoreServiceProto.CreateProjectRequest request =
+        CoreServiceProto.CreateProjectRequest.newBuilder().setName(name).build();
+    CoreServiceProto.CreateProjectResponse response = stub.createProject(request);
+    return response != null;
+  }
+
+  /**
+   * Archives a project. Archived projects will continue to exist and function, but won't be visible
+   * through the Core API. Any existing ingestion or serving requests will continue to function, but
+   * will result in warning messages being logged. It is not possible to unarchive a project through
+   * the Core API.
+   *
+   * @param name of the project to archive.
+   * @return true if request returned, false otherwise.
+   */
+  public boolean archiveProject(String name) {
+    CoreServiceProto.ArchiveProjectRequest request =
+        CoreServiceProto.ArchiveProjectRequest.newBuilder().setName(name).build();
+    CoreServiceProto.ArchiveProjectResponse response = stub.archiveProject(request);
+    return response != null;
+  }
+
+  /**
+   * List all active projects.
+   *
+   * @return the list of project names.
+   */
+  public List<String> listProjects() {
+    return stub.listProjects(CoreServiceProto.ListProjectsRequest.newBuilder().build())
+        .getProjectsList();
+  }
+
+  /**
+   * Returns a specific entity.
+   *
+   * @param project name
+   * @param name of the entity
+   * @return Optional of {@link Entity}
+   */
+  public Optional<Entity> getEntity(String project, String name) {
+    CoreServiceProto.GetEntityRequest.Builder request =
+        CoreServiceProto.GetEntityRequest.newBuilder().setProject(project).setName(name);
+    CoreServiceProto.GetEntityResponse response = stub.getEntity(request.build());
+    Entity entity = response.hasEntity() ? new Entity(response.getEntity()) : null;
+    return Optional.ofNullable(entity);
+  }
+
+  /**
+   * Create or update and existing entity. Schema changes will update the entity if the changes are
+   * valid. Can't update name or type.
+   *
+   * @param entitySpec {@link Entity.Spec}
+   * @return Optional of {@link Entity}
+   */
+  public Optional<Entity> apply(Entity.Spec entitySpec) {
+    CoreServiceProto.ApplyEntityRequest.Builder request =
+        CoreServiceProto.ApplyEntityRequest.newBuilder()
+            .setProject(entitySpec.getProject())
+            .setSpec(entitySpec.toProto());
+    CoreServiceProto.ApplyEntityResponse response = stub.applyEntity(request.build());
+    Entity entity = response.hasEntity() ? new Entity(response.getEntity()) : null;
+    return Optional.ofNullable(entity);
+  }
+
+  /**
+   * List all entities under a certain project.
+   *
+   * @param project specifies the name of the project to list Entities in.
+   * @return all entity references under projectt.
+   */
+  public List<Entity> listEntities(String project) {
+    return listEntities(project, null);
+  }
+
+  /**
+   * List all entities under a certain project.
+   *
+   * @param project specifies the name of the project to list Entities in.
+   * @param labels are User defined metadata for entity. Entities with all matching labels will be
+   *     returned.
+   * @return all entity references and respective entities matching labels under project.
+   */
+  public List<Entity> listEntities(String project, Map<String, String> labels) {
+    CoreServiceProto.ListEntitiesRequest.Filter.Builder filter =
+        CoreServiceProto.ListEntitiesRequest.Filter.newBuilder().setProject(project);
+    if (labels != null) filter.putAllLabels(labels);
+    CoreServiceProto.ListEntitiesRequest request =
+        CoreServiceProto.ListEntitiesRequest.newBuilder().setFilter(filter).build();
+    List<EntityProto.Entity> entities = stub.listEntities(request).getEntitiesList();
+    return entities.stream().map(Entity::new).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a specific feature table.
+   *
+   * @param project name
+   * @param name of the feature table
+   * @return Optional of {@link FeatureTable}
+   */
+  public Optional<FeatureTable> getFeatureTable(String project, String name) {
+    CoreServiceProto.GetFeatureTableRequest.Builder request =
+        CoreServiceProto.GetFeatureTableRequest.newBuilder().setProject(project).setName(name);
+    CoreServiceProto.GetFeatureTableResponse response = stub.getFeatureTable(request.build());
+    FeatureTable featureTable = response.hasTable() ? new FeatureTable(response.getTable()) : null;
+    return Optional.ofNullable(featureTable);
+  }
+
+  /**
+   * Create or update an existing feature table. Schema changes will update the feature table if the
+   * changes are valid. Can't update name, entities and feature names and types.
+   *
+   * @param featureTableSpec {@link FeatureTable.Spec}
+   * @return Optional of {@link FeatureTable}
+   */
+  public Optional<FeatureTable> apply(FeatureTable.Spec featureTableSpec) {
+    CoreServiceProto.ApplyFeatureTableRequest.Builder request =
+        CoreServiceProto.ApplyFeatureTableRequest.newBuilder()
+            .setProject(featureTableSpec.getProject())
+            .setTableSpec(featureTableSpec.toProto());
+    CoreServiceProto.ApplyFeatureTableResponse response = stub.applyFeatureTable(request.build());
+    FeatureTable featureTable = response.hasTable() ? new FeatureTable(response.getTable()) : null;
+    return Optional.ofNullable(featureTable);
+  }
+
+  /**
+   * List all Feature Tables under a project.
+   *
+   * @param project name.
+   * @return a list of the matching {@link FeatureTable}.
+   */
+  public List<FeatureTable> listFeatureTables(String project) {
+    return listFeatureTables(project, null);
+  }
+
+  /**
+   * List all Feature Tables under a project.
+   *
+   * @param project name.
+   * @param labels on Feature Tables will be returned.
+   * @return a list of the matching {@link FeatureTable}.
+   */
+  public List<FeatureTable> listFeatureTables(String project, Map<String, String> labels) {
+    CoreServiceProto.ListFeatureTablesRequest.Filter.Builder filter =
+        CoreServiceProto.ListFeatureTablesRequest.Filter.newBuilder().setProject(project);
+    if (labels != null) filter.putAllLabels(labels);
+    CoreServiceProto.ListFeatureTablesRequest request =
+        CoreServiceProto.ListFeatureTablesRequest.newBuilder().setFilter(filter).build();
+    List<FeatureTableProto.FeatureTable> featureTables =
+        stub.listFeatureTables(request).getTablesList();
+    return featureTables.stream().map(FeatureTable::new).collect(Collectors.toList());
+  }
+
+  /**
+   * @param project name that the feature tables belongs to
+   * @param entities contained within the featureSet that the feature belongs to. Only feature
+   *     tables with these entities will be searched for features. If none are specified all Feature
+   *     Tables will be seeked.
+   * @return list of Features matching the parameters.
+   */
+  public List<Feature> listFeatures(String project, String... entities) {
+    return listFeatures(project, Arrays.asList(entities), null);
+  }
+
+  /**
+   * @param project name that the feature tables belongs to
+   * @param entities contained within the featureSet that the feature belongs to. Only feature
+   *     tables with these entities will be searched for features.
+   * @param labels are user defined metadata for feature. Features with all matching labels will be
+   *     returned.
+   * @return list of Features matching the parameters.
+   */
+  public List<Feature> listFeatures(
+      String project, List<String> entities, Map<String, String> labels) {
+    CoreServiceProto.ListFeaturesRequest.Filter.Builder filter =
+        CoreServiceProto.ListFeaturesRequest.Filter.newBuilder().setProject(project);
+    if (entities != null) filter.addAllEntities(entities);
+    if (labels != null) filter.putAllLabels(labels);
+    CoreServiceProto.ListFeaturesRequest request =
+        CoreServiceProto.ListFeaturesRequest.newBuilder().setFilter(filter).build();
+    Map<String, FeatureProto.FeatureSpecV2> features = stub.listFeatures(request).getFeaturesMap();
+    return features.values().stream().map(Feature::new).collect(Collectors.toList());
+  }
+
+  /**
+   * Delete a specific Feature Table.
+   *
+   * @param project Name of the Project to delete the Feature Table from.
+   * @param name of the FeatureTable to delete.
+   * @return true if request returned, false otherwise.
+   */
+  public boolean deleteFeatureTable(String project, String name) {
+    CoreServiceProto.DeleteFeatureTableRequest request =
+        CoreServiceProto.DeleteFeatureTableRequest.newBuilder()
+            .setProject(project)
+            .setName(name)
+            .build();
+    return stub.deleteFeatureTable(request) != null;
+  }
+
+  protected CoreClient(String host, int port, SecurityConfig securityConfig) {
+    super(host, port, securityConfig);
+  }
+
+  protected CoreClient(ManagedChannel channel, Optional<CallCredentials> credentials) {
+    super(channel, credentials);
+  }
+
+  @Override
+  protected CoreServiceBlockingStub getStub(Channel channel) {
+    return CoreServiceGrpc.newBlockingStub(channel);
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/CoreClient.java
@@ -124,7 +124,8 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
             .setProject(entitySpec.getProject())
             .setSpec(entitySpec.toProto());
     CoreServiceProto.ApplyEntityResponse response = stub.applyEntity(request.build());
-    Entity entity = response.hasEntity() ? new Entity(entitySpec.getProject(), response.getEntity()) : null;
+    Entity entity =
+        response.hasEntity() ? new Entity(entitySpec.getProject(), response.getEntity()) : null;
     return Optional.ofNullable(entity);
   }
 
@@ -167,7 +168,8 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
     CoreServiceProto.GetFeatureTableRequest.Builder request =
         CoreServiceProto.GetFeatureTableRequest.newBuilder().setProject(project).setName(name);
     CoreServiceProto.GetFeatureTableResponse response = stub.getFeatureTable(request.build());
-    FeatureTable featureTable = response.hasTable() ? new FeatureTable(project, response.getTable()) : null;
+    FeatureTable featureTable =
+        response.hasTable() ? new FeatureTable(project, response.getTable()) : null;
     return Optional.ofNullable(featureTable);
   }
 
@@ -184,7 +186,10 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
             .setProject(featureTableSpec.getProject())
             .setTableSpec(featureTableSpec.toProto());
     CoreServiceProto.ApplyFeatureTableResponse response = stub.applyFeatureTable(request.build());
-    FeatureTable featureTable = response.hasTable() ? new FeatureTable(featureTableSpec.getProject(), response.getTable()) : null;
+    FeatureTable featureTable =
+        response.hasTable()
+            ? new FeatureTable(featureTableSpec.getProject(), response.getTable())
+            : null;
     return Optional.ofNullable(featureTable);
   }
 
@@ -213,7 +218,9 @@ public class CoreClient extends GrpcManager<CoreServiceBlockingStub> {
         CoreServiceProto.ListFeatureTablesRequest.newBuilder().setFilter(filter).build();
     List<FeatureTableProto.FeatureTable> featureTables =
         stub.listFeatureTables(request).getTablesList();
-    return featureTables.stream().map(proto -> new FeatureTable(project, proto)).collect(Collectors.toList());
+    return featureTables.stream()
+        .map(proto -> new FeatureTable(project, proto))
+        .collect(Collectors.toList());
   }
 
   /**

--- a/sdk/java/src/main/java/com/gojek/feast/core/Entity.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/Entity.java
@@ -29,7 +29,6 @@ public class Entity {
     private final String project;
     private final ValueType value;
     private final String description;
-    private final String joinKey;
     private final Map<String, String> labels;
 
     protected Spec(
@@ -37,13 +36,11 @@ public class Entity {
         String name,
         ValueType value,
         String description,
-        String joinKey,
         Map<String, String> labels) {
       this.name = name;
       this.project = project;
       this.value = value;
       this.description = description;
-      this.joinKey = joinKey;
       this.labels = labels;
     }
 
@@ -56,7 +53,6 @@ public class Entity {
       private final String project;
       private ValueType value;
       private String description;
-      private String joinKey;
       private final Map<String, String> labels = new HashMap<>();
 
       private Builder(String project, String name) {
@@ -74,11 +70,6 @@ public class Entity {
         return this;
       }
 
-      public Builder setJoinKey(String joinKey) {
-        this.joinKey = joinKey;
-        return this;
-      }
-
       public Builder addLabel(String key, String val) {
         this.labels.put(key, val);
         return this;
@@ -90,7 +81,7 @@ public class Entity {
       }
 
       public Spec build() {
-        return new Spec(project, name, value, description, joinKey, labels);
+        return new Spec(project, name, value, description, labels);
       }
     }
 
@@ -110,30 +101,23 @@ public class Entity {
       return description;
     }
 
-    public String getJoinKey() {
-      return joinKey;
-    }
-
     public Map<String, String> getLabels() {
       return labels;
     }
 
-    protected Spec(EntityProto.EntitySpecV2 spec) {
+    protected Spec(String project, EntityProto.EntitySpecV2 spec) {
+      this.project = project;
       this.name = spec.getName();
-      this.project = spec.getProject();
       this.value = ValueType.fromProto(spec.getValueType());
       this.description = spec.getDescription();
-      this.joinKey = spec.getJoinKey();
       this.labels = spec.getLabelsMap();
     }
 
     protected EntityProto.EntitySpecV2 toProto() {
       return EntityProto.EntitySpecV2.newBuilder()
           .setName(name)
-          .setProject(project)
           .setValueType(value.toProto())
           .setDescription(description)
-          .setJoinKey(joinKey)
           .putAllLabels(labels)
           .build();
     }
@@ -147,8 +131,8 @@ public class Entity {
     return metadata;
   }
 
-  protected Entity(EntityProto.Entity entity) {
-    if (entity.hasSpec()) this.spec = new Spec(entity.getSpec());
+  protected Entity(String project, EntityProto.Entity entity) {
+    if (entity.hasSpec()) this.spec = new Spec(project, entity.getSpec());
     if (entity.hasMeta()) this.metadata = new Metadata(entity.getMeta());
   }
 

--- a/sdk/java/src/main/java/com/gojek/feast/core/Entity.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/Entity.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import feast.proto.core.EntityProto;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Entity {
+  private Spec spec;
+  private Metadata metadata;
+
+  public static class Spec {
+    private final String name;
+    private final String project;
+    private final ValueType value;
+    private final String description;
+    private final String joinKey;
+    private final Map<String, String> labels;
+
+    protected Spec(
+        String project,
+        String name,
+        ValueType value,
+        String description,
+        String joinKey,
+        Map<String, String> labels) {
+      this.name = name;
+      this.project = project;
+      this.value = value;
+      this.description = description;
+      this.joinKey = joinKey;
+      this.labels = labels;
+    }
+
+    public static Builder getBuilder(String name, String project) {
+      return new Builder(name, project);
+    }
+
+    public static class Builder {
+      private final String name;
+      private final String project;
+      private ValueType value;
+      private String description;
+      private String joinKey;
+      private final Map<String, String> labels = new HashMap<>();
+
+      private Builder(String project, String name) {
+        this.project = project;
+        this.name = name;
+      }
+
+      public Builder setValue(ValueType value) {
+        this.value = value;
+        return this;
+      }
+
+      public Builder setDescription(String description) {
+        this.description = description;
+        return this;
+      }
+
+      public Builder setJoinKey(String joinKey) {
+        this.joinKey = joinKey;
+        return this;
+      }
+
+      public Builder addLabel(String key, String val) {
+        this.labels.put(key, val);
+        return this;
+      }
+
+      public Builder addLabels(Map<String, String> labels) {
+        this.labels.putAll(labels);
+        return this;
+      }
+
+      public Spec build() {
+        return new Spec(project, name, value, description, joinKey, labels);
+      }
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getProject() {
+      return project;
+    }
+
+    public ValueType getValue() {
+      return value;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public String getJoinKey() {
+      return joinKey;
+    }
+
+    public Map<String, String> getLabels() {
+      return labels;
+    }
+
+    protected Spec(EntityProto.EntitySpecV2 spec) {
+      this.name = spec.getName();
+      this.project = spec.getProject();
+      this.value = ValueType.fromProto(spec.getValueType());
+      this.description = spec.getDescription();
+      this.joinKey = spec.getJoinKey();
+      this.labels = spec.getLabelsMap();
+    }
+
+    protected EntityProto.EntitySpecV2 toProto() {
+      return EntityProto.EntitySpecV2.newBuilder()
+          .setName(name)
+          .setProject(project)
+          .setValueType(value.toProto())
+          .setDescription(description)
+          .setJoinKey(joinKey)
+          .putAllLabels(labels)
+          .build();
+    }
+  }
+
+  public Spec getSpec() {
+    return spec;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  protected Entity(EntityProto.Entity entity) {
+    if (entity.hasSpec()) this.spec = new Spec(entity.getSpec());
+    if (entity.hasMeta()) this.metadata = new Metadata(entity.getMeta());
+  }
+
+  protected EntityProto.Entity toProto() {
+    return EntityProto.Entity.newBuilder()
+        .setSpec(spec.toProto())
+        .setMeta(
+            EntityProto.EntityMeta.newBuilder()
+                .setCreatedTimestamp(Metadata.toProto(metadata.getCreatedTimestamp()))
+                .setLastUpdatedTimestamp(Metadata.toProto(metadata.getLastUpdatedTimestamp())))
+        .build();
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/Feature.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/Feature.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import feast.proto.core.FeatureProto;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Feature {
+  private final String name;
+  private final ValueType valueType;
+  private final Map<String, String> labels;
+
+  public static Builder getBuilder(String name, ValueType valueType) {
+    return new Builder(name, valueType);
+  }
+
+  protected Feature(String name, ValueType valueType, Map<String, String> labels) {
+    this.name = name;
+    this.valueType = valueType;
+    this.labels = labels;
+  }
+
+  public static class Builder {
+    private final String name;
+    private final ValueType valueType;
+    private final Map<String, String> labels = new HashMap<>();
+
+    private Builder(String name, ValueType valueType) {
+      this.name = name;
+      this.valueType = valueType;
+    }
+
+    public Builder addLabel(String key, String val) {
+      this.labels.put(key, val);
+      return this;
+    }
+
+    public Builder addLabels(Map<String, String> labels) {
+      this.labels.putAll(labels);
+      return this;
+    }
+
+    public Feature build() {
+      return new Feature(name, valueType, labels);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ValueType getValueType() {
+    return valueType;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  protected Feature(FeatureProto.FeatureSpecV2 feature) {
+    this.name = feature.getName();
+    this.valueType = ValueType.fromProto(feature.getValueType());
+    this.labels = feature.getLabelsMap();
+  }
+
+  protected FeatureProto.FeatureSpecV2 toProto() {
+    return FeatureProto.FeatureSpecV2.newBuilder()
+        .setName(name)
+        .setValueType(valueType.toProto())
+        .putAllLabels(labels)
+        .build();
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/FeatureTable.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/FeatureTable.java
@@ -138,8 +138,8 @@ public class FeatureTable {
       return Optional.ofNullable(maxAge);
     }
 
-    protected Spec(FeatureTableProto.FeatureTableSpec spec) {
-      this.project = spec.getProject();
+    protected Spec(String project, FeatureTableProto.FeatureTableSpec spec) {
+      this.project = project;
       this.name = spec.getName();
       this.entities = spec.getEntitiesList();
       this.features =
@@ -153,7 +153,6 @@ public class FeatureTable {
     protected FeatureTableProto.FeatureTableSpec toProto() {
       FeatureTableProto.FeatureTableSpec.Builder builder =
           FeatureTableProto.FeatureTableSpec.newBuilder()
-              .setProject(project)
               .setName(name)
               .addAllEntities(entities)
               .addAllFeatures(features.stream().map(Feature::toProto).collect(Collectors.toList()))
@@ -177,8 +176,8 @@ public class FeatureTable {
     return metadata;
   }
 
-  protected FeatureTable(FeatureTableProto.FeatureTable featureTable) {
-    if (featureTable.hasSpec()) this.spec = new Spec(featureTable.getSpec());
+  protected FeatureTable(String project, FeatureTableProto.FeatureTable featureTable) {
+    if (featureTable.hasSpec()) this.spec = new Spec(project, featureTable.getSpec());
     if (featureTable.hasMeta()) this.metadata = new Metadata(featureTable.getMeta());
   }
 

--- a/sdk/java/src/main/java/com/gojek/feast/core/FeatureTable.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/FeatureTable.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import feast.proto.core.FeatureTableProto;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class FeatureTable {
+  private Spec spec;
+  private Metadata metadata;
+
+  public static class Spec {
+    private final String project;
+    private final String name;
+    private final List<String> entities;
+    private final List<Feature> features;
+    private final Map<String, String> labels;
+    private Duration maxAge;
+
+    protected Spec(
+        String project,
+        String name,
+        List<String> entities,
+        List<Feature> features,
+        Map<String, String> labels,
+        Duration maxAge) {
+      this.project = project;
+      this.name = name;
+      this.entities = entities;
+      this.features = features;
+      this.labels = labels;
+      this.maxAge = maxAge;
+    }
+
+    protected Spec(
+        String project,
+        String name,
+        List<String> entities,
+        List<Feature> features,
+        Map<String, String> labels) {
+      this(project, name, entities, features, labels, null);
+    }
+
+    public static Builder getBuilder(String project, String name) {
+      return new Builder(project, name);
+    }
+
+    public static class Builder {
+      private final String project;
+      private final String name;
+      private final List<String> entities = new LinkedList<>();
+      private final List<Feature> features = new LinkedList<>();
+      private final Map<String, String> labels = new HashMap<>();
+      private Duration maxAge;
+
+      private Builder(String project, String name) {
+        this.project = project;
+        this.name = name;
+      }
+
+      public Spec build() {
+        return new Spec(project, name, entities, features, labels, maxAge);
+      }
+
+      public Builder addEntity(String entity) {
+        this.entities.add(entity);
+        return this;
+      }
+
+      public Builder addEntities(Collection<String> entities) {
+        this.entities.addAll(entities);
+        return this;
+      }
+
+      public Builder addFeature(Feature feature) {
+        this.features.add(feature);
+        return this;
+      }
+
+      public Builder addFeatures(Collection<? extends Feature> features) {
+        this.features.addAll(features);
+        return this;
+      }
+
+      public Builder addLabel(String key, String val) {
+        this.labels.put(key, val);
+        return this;
+      }
+
+      public Builder addLabels(Map<String, String> labels) {
+        this.labels.putAll(labels);
+        return this;
+      }
+
+      public Builder setMaxAge(Duration maxAge) {
+        this.maxAge = maxAge;
+        return this;
+      }
+    }
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public List<String> getEntities() {
+      return entities;
+    }
+
+    public List<Feature> getFeatures() {
+      return features;
+    }
+
+    public Map<String, String> getLabels() {
+      return labels;
+    }
+
+    public Optional<Duration> getMaxAge() {
+      return Optional.ofNullable(maxAge);
+    }
+
+    protected Spec(FeatureTableProto.FeatureTableSpec spec) {
+      this.project = spec.getProject();
+      this.name = spec.getName();
+      this.entities = spec.getEntitiesList();
+      this.features =
+          spec.getFeaturesList().stream().map(Feature::new).collect(Collectors.toList());
+      this.labels = spec.getLabelsMap();
+      if (spec.hasMaxAge())
+        this.maxAge =
+            Duration.ofSeconds(spec.getMaxAge().getSeconds(), spec.getMaxAge().getNanos());
+    }
+
+    protected FeatureTableProto.FeatureTableSpec toProto() {
+      FeatureTableProto.FeatureTableSpec.Builder builder =
+          FeatureTableProto.FeatureTableSpec.newBuilder()
+              .setProject(project)
+              .setName(name)
+              .addAllEntities(entities)
+              .addAllFeatures(features.stream().map(Feature::toProto).collect(Collectors.toList()))
+              .putAllLabels(labels);
+      if (maxAge != null) {
+        builder.setMaxAge(
+            com.google.protobuf.Duration.newBuilder()
+                .setSeconds(maxAge.getSeconds())
+                .setNanos(maxAge.getNano())
+                .build());
+      }
+      return builder.build();
+    }
+  }
+
+  public Spec getSpec() {
+    return spec;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  protected FeatureTable(FeatureTableProto.FeatureTable featureTable) {
+    if (featureTable.hasSpec()) this.spec = new Spec(featureTable.getSpec());
+    if (featureTable.hasMeta()) this.metadata = new Metadata(featureTable.getMeta());
+  }
+
+  protected FeatureTableProto.FeatureTable toProto() {
+    return FeatureTableProto.FeatureTable.newBuilder()
+        .setSpec(spec.toProto())
+        .setMeta(
+            FeatureTableProto.FeatureTableMeta.newBuilder()
+                .setLastUpdatedTimestamp(Metadata.toProto(metadata.getLastUpdatedTimestamp()))
+                .setCreatedTimestamp(Metadata.toProto(metadata.getCreatedTimestamp())))
+        .build();
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/Metadata.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/Metadata.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import com.google.protobuf.Timestamp;
+import feast.proto.core.EntityProto;
+import feast.proto.core.FeatureTableProto;
+import java.time.Instant;
+
+public class Metadata {
+  private final Instant createdTimestamp;
+  private final Instant lastUpdatedTimestamp;
+
+  protected Metadata(EntityProto.EntityMeta meta) {
+    this.createdTimestamp = toInstant(meta.getCreatedTimestamp());
+    this.lastUpdatedTimestamp = toInstant(meta.getLastUpdatedTimestamp());
+  }
+
+  protected Metadata(FeatureTableProto.FeatureTableMeta meta) {
+    this.createdTimestamp = toInstant(meta.getCreatedTimestamp());
+    this.lastUpdatedTimestamp = toInstant(meta.getLastUpdatedTimestamp());
+  }
+
+  public Instant getCreatedTimestamp() {
+    return createdTimestamp;
+  }
+
+  public Instant getLastUpdatedTimestamp() {
+    return lastUpdatedTimestamp;
+  }
+
+  protected static Instant toInstant(Timestamp timestamp) {
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
+  }
+
+  protected static Timestamp toProto(Instant instant) {
+    return Timestamp.newBuilder().setSeconds(instant.getEpochSecond()).build();
+  }
+}

--- a/sdk/java/src/main/java/com/gojek/feast/core/ValueType.java
+++ b/sdk/java/src/main/java/com/gojek/feast/core/ValueType.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import feast.proto.types.ValueProto;
+import java.util.Arrays;
+
+public enum ValueType {
+  INVALID(0),
+  BYTES(1),
+  STRING(2),
+  INT32(3),
+  INT64(4),
+  DOUBLE(5),
+  FLOAT(6),
+  BOOL(7),
+  UNIX_TIMESTAMP(8),
+  BYTES_LIST(11),
+  STRING_LIST(12),
+  INT32_LIST(13),
+  INT64_LIST(14),
+  DOUBLE_LIST(15),
+  FLOAT_LIST(16),
+  BOOL_LIST(17),
+  UNIX_TIMESTAMP_LIST(18);
+
+  /** @param number - is the matching {@link feast.proto.types.ValueProto.Value} enumeration */
+  ValueType(int number) {
+    this.number = number;
+  }
+
+  private final int number;
+
+  static ValueType fromProto(ValueProto.ValueType.Enum valueType) {
+    return Arrays.stream(values())
+        .filter(value -> value.number == valueType.getNumber())
+        .findFirst()
+        .orElse(INVALID);
+  }
+
+  ValueProto.ValueType.Enum toProto() {
+    return ValueProto.ValueType.Enum.forNumber(number);
+  }
+
+  int getNumber() {
+    return this.number;
+  }
+}

--- a/sdk/java/src/test/java/com/gojek/feast/GrpcMock.java
+++ b/sdk/java/src/test/java/com/gojek/feast/GrpcMock.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast;
+
+import io.grpc.*;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Rule;
+
+public class GrpcMock {
+
+  @Rule public GrpcCleanupRule grpcRule;
+  protected AtomicBoolean isAuthenticated;
+  private ManagedChannel channel;
+
+  public GrpcMock(BindableService server) throws IOException {
+    this.grpcRule = new GrpcCleanupRule();
+    this.isAuthenticated = new AtomicBoolean(false);
+    // setup fake serving service
+    String serverName = InProcessServerBuilder.generateName();
+    this.grpcRule.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(server)
+            .intercept(mockAuthInterceptor)
+            .build()
+            .start());
+    // setup test feast client target
+    this.channel =
+        this.grpcRule.register(
+            InProcessChannelBuilder.forName(serverName).directExecutor().build());
+  }
+
+  // Mock Authentication interceptor will flag authenticated request by setting isAuthenticated to
+  // true.
+  private final ServerInterceptor mockAuthInterceptor =
+      new ServerInterceptor() {
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+          final Metadata.Key<String> authorizationKey =
+              Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+          if (headers.containsKey(authorizationKey)) {
+            isAuthenticated.set(true);
+          }
+          return next.startCall(call, headers);
+        }
+      };
+
+  public ManagedChannel getChannel() {
+    return channel;
+  }
+
+  public boolean isAuthenticated() {
+    return isAuthenticated.get();
+  }
+
+  public void resetAuthentication() {
+    isAuthenticated.set(false);
+  }
+}

--- a/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
@@ -57,7 +57,6 @@ public class CoreClientTest {
         Entity.Spec.getBuilder(CoreServiceImplMock.PROJECT, name)
             .setValue(ValueType.BOOL)
             .setDescription("description")
-            .setJoinKey("joinKey")
             .build();
     client.apply(spec);
     Assertions.assertEquals(

--- a/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+
+import com.gojek.feast.GrpcMock;
+import feast.proto.core.CoreServiceGrpc;
+import java.util.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
+public class CoreClientTest {
+
+  private final CoreServiceGrpc.CoreServiceImplBase coreMock =
+      mock(CoreServiceGrpc.CoreServiceImplBase.class, delegatesTo(new CoreServiceImplMock()));
+
+  private CoreClient client;
+
+  @Before
+  public void setup() throws Exception {
+    GrpcMock grpcMock = new GrpcMock(this.coreMock);
+    this.client = new CoreClient(grpcMock.getChannel(), Optional.empty());
+  }
+
+  @BeforeEach
+  void setUp() {
+    CoreServiceImplMock.clear();
+  }
+
+  @Test
+  public void testProject() {
+    Assertions.assertEquals(CoreServiceImplMock.PROJECT, client.listProjects().get(0));
+  }
+
+  @Test
+  public void testEntity() {
+    final String name = "entity";
+    Entity.Spec spec =
+        Entity.Spec.getBuilder(CoreServiceImplMock.PROJECT, name)
+            .setValue(ValueType.BOOL)
+            .setDescription("description")
+            .setJoinKey("joinKey")
+            .build();
+    client.apply(spec);
+    Assertions.assertEquals(
+        spec.toProto(),
+        client.getEntity(CoreServiceImplMock.PROJECT, name).get().getSpec().toProto());
+    spec.getLabels().put("l1", "v1");
+    client.apply(spec);
+    Assertions.assertTrue(
+        client
+            .getEntity(CoreServiceImplMock.PROJECT, name)
+            .get()
+            .getSpec()
+            .getLabels()
+            .containsKey("l1"));
+    Assertions.assertEquals(1, client.listEntities(CoreServiceImplMock.PROJECT).size());
+  }
+
+  @Test
+  public void testFeatureTable() {
+    final String name = "featureTable";
+    FeatureTable.Spec spec =
+        FeatureTable.Spec.getBuilder(CoreServiceImplMock.PROJECT, name)
+            .addEntity("entity")
+            .addLabel("key", "value")
+            .build();
+    client.apply(spec);
+    Assertions.assertEquals(
+        spec.toProto(),
+        client.getFeatureTable(CoreServiceImplMock.PROJECT, name).get().getSpec().toProto());
+    spec.getFeatures().add(Feature.getBuilder("feature", ValueType.FLOAT).build());
+    client.apply(spec);
+    Assertions.assertTrue(
+        client.getFeatureTable(CoreServiceImplMock.PROJECT, name).get().getSpec().getFeatures()
+            .stream()
+            .anyMatch(f -> f.getName().equals("feature")));
+    Assertions.assertEquals(1, client.listFeatureTables(CoreServiceImplMock.PROJECT).size());
+    Assertions.assertEquals(1, client.listFeatures(CoreServiceImplMock.PROJECT).size());
+    client.deleteFeatureTable(CoreServiceImplMock.PROJECT, name);
+    Assertions.assertTrue(client.listFeatureTables(CoreServiceImplMock.PROJECT).isEmpty());
+  }
+}

--- a/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/CoreClientTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.gojek.feast.GrpcMock;
 import feast.proto.core.CoreServiceGrpc;
+import feast.proto.core.DataSourceProto;
 import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,6 +82,10 @@ public class CoreClientTest {
         FeatureTable.Spec.getBuilder(CoreServiceImplMock.PROJECT, name)
             .addEntity("entity")
             .addLabel("key", "value")
+            .setBatchSource(
+                DataSourceProto.DataSource.newBuilder()
+                    .setType(DataSourceProto.DataSource.SourceType.BATCH_FILE)
+                    .build())
             .build();
     client.apply(spec);
     Assertions.assertEquals(

--- a/sdk/java/src/test/java/com/gojek/feast/core/CoreServiceImplMock.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/CoreServiceImplMock.java
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import com.google.protobuf.Timestamp;
+import feast.proto.core.CoreServiceGrpc;
+import feast.proto.core.CoreServiceProto;
+import feast.proto.core.EntityProto;
+import feast.proto.core.FeatureTableProto;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CoreServiceImplMock extends CoreServiceGrpc.CoreServiceImplBase {
+  protected static final String PROJECT = "project";
+
+  private static final Map<String, EntityProto.Entity.Builder> entities = new ConcurrentHashMap<>();
+  private static final Map<String, FeatureTableProto.FeatureTable.Builder> featureTables =
+      new ConcurrentHashMap<>();
+
+  public static void clear() {
+    entities.clear();
+    featureTables.clear();
+  }
+
+  @Override
+  public void getEntity(
+      CoreServiceProto.GetEntityRequest request,
+      StreamObserver<CoreServiceProto.GetEntityResponse> responseObserver) {
+    if (!request.getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    CoreServiceProto.GetEntityResponse.Builder response =
+        CoreServiceProto.GetEntityResponse.newBuilder();
+    entities.computeIfPresent(
+        request.getName(),
+        (k, v) -> {
+          response.setEntity(v);
+          return v;
+        });
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void applyEntity(
+      CoreServiceProto.ApplyEntityRequest request,
+      StreamObserver<CoreServiceProto.ApplyEntityResponse> responseObserver) {
+    if (!request.getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    EntityProto.EntitySpecV2 spec = request.getSpec();
+    EntityProto.Entity.Builder entity =
+        entities.computeIfAbsent(
+            request.getSpec().getName(),
+            k ->
+                EntityProto.Entity.newBuilder()
+                    .setSpec(spec)
+                    .setMeta(EntityProto.EntityMeta.newBuilder().setCreatedTimestamp(now())));
+    EntityProto.EntitySpecV2 oldSpec = entity.getSpec();
+    if (!oldSpec.getName().equals(spec.getName())
+        || !oldSpec.getValueType().equals(spec.getValueType()))
+      responseObserver.onError(Status.INVALID_ARGUMENT.asRuntimeException());
+    entity.setSpec(spec).getMetaBuilder().setLastUpdatedTimestamp(now());
+    responseObserver.onNext(
+        CoreServiceProto.ApplyEntityResponse.newBuilder().setEntity(entity).build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void applyFeatureTable(
+      CoreServiceProto.ApplyFeatureTableRequest request,
+      StreamObserver<CoreServiceProto.ApplyFeatureTableResponse> responseObserver) {
+    if (!request.getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    FeatureTableProto.FeatureTableSpec spec = request.getTableSpec();
+    FeatureTableProto.FeatureTable.Builder featureTable =
+        featureTables.computeIfAbsent(
+            spec.getName(),
+            k ->
+                FeatureTableProto.FeatureTable.newBuilder()
+                    .setSpec(spec)
+                    .setMeta(
+                        FeatureTableProto.FeatureTableMeta.newBuilder()
+                            .setCreatedTimestamp(now())));
+    FeatureTableProto.FeatureTableSpec oldSpec = featureTable.getSpec();
+    if (!oldSpec.getName().equals(spec.getName())
+        || !oldSpec.getEntitiesList().equals(spec.getEntitiesList()))
+      responseObserver.onError(Status.INVALID_ARGUMENT.asRuntimeException());
+    featureTable.setSpec(spec).getMetaBuilder().setLastUpdatedTimestamp(now());
+    responseObserver.onNext(
+        CoreServiceProto.ApplyFeatureTableResponse.newBuilder().setTable(featureTable).build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getFeatureTable(
+      CoreServiceProto.GetFeatureTableRequest request,
+      StreamObserver<CoreServiceProto.GetFeatureTableResponse> responseObserver) {
+    if (!request.getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    CoreServiceProto.GetFeatureTableResponse.Builder response =
+        CoreServiceProto.GetFeatureTableResponse.newBuilder();
+    featureTables.computeIfPresent(
+        request.getName(),
+        (k, v) -> {
+          response.setTable(v);
+          return v;
+        });
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listFeatures(
+      CoreServiceProto.ListFeaturesRequest request,
+      StreamObserver<CoreServiceProto.ListFeaturesResponse> responseObserver) {
+    if (!request.getFilter().getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    if (request.getFilter().getEntitiesCount() > 0 || request.getFilter().getLabelsCount() > 0)
+      responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+    CoreServiceProto.ListFeaturesResponse.Builder response =
+        CoreServiceProto.ListFeaturesResponse.newBuilder();
+    featureTables.values().stream()
+        .flatMap(featureTable -> featureTable.getSpec().getFeaturesList().stream())
+        .forEach(feature -> response.putFeatures(feature.getName(), feature));
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listEntities(
+      CoreServiceProto.ListEntitiesRequest request,
+      StreamObserver<CoreServiceProto.ListEntitiesResponse> responseObserver) {
+    if (!request.getFilter().getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    if (request.getFilter().getLabelsCount() > 0)
+      responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+    CoreServiceProto.ListEntitiesResponse.Builder response =
+        CoreServiceProto.ListEntitiesResponse.newBuilder();
+    entities.values().forEach(response::addEntities);
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void createProject(
+      CoreServiceProto.CreateProjectRequest request,
+      StreamObserver<CoreServiceProto.CreateProjectResponse> responseObserver) {
+    responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+  }
+
+  @Override
+  public void archiveProject(
+      CoreServiceProto.ArchiveProjectRequest request,
+      StreamObserver<CoreServiceProto.ArchiveProjectResponse> responseObserver) {
+    responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+  }
+
+  @Override
+  public void listProjects(
+      CoreServiceProto.ListProjectsRequest request,
+      StreamObserver<CoreServiceProto.ListProjectsResponse> responseObserver) {
+    responseObserver.onNext(
+        CoreServiceProto.ListProjectsResponse.newBuilder().addProjects(PROJECT).build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listFeatureTables(
+      CoreServiceProto.ListFeatureTablesRequest request,
+      StreamObserver<CoreServiceProto.ListFeatureTablesResponse> responseObserver) {
+    if (!request.getFilter().getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    if (request.getFilter().getLabelsCount() > 0)
+      responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+    CoreServiceProto.ListFeatureTablesResponse.Builder response =
+        CoreServiceProto.ListFeatureTablesResponse.newBuilder();
+    featureTables.values().forEach(response::addTables);
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void deleteFeatureTable(
+      CoreServiceProto.DeleteFeatureTableRequest request,
+      StreamObserver<CoreServiceProto.DeleteFeatureTableResponse> responseObserver) {
+    if (!request.getProject().equals(PROJECT))
+      responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
+    featureTables.remove(request.getName());
+    CoreServiceProto.DeleteFeatureTableResponse.Builder response =
+        CoreServiceProto.DeleteFeatureTableResponse.newBuilder();
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+  }
+
+  private Timestamp now() {
+    return Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build();
+  }
+}

--- a/sdk/java/src/test/java/com/gojek/feast/core/ProtobufSerializationTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/ProtobufSerializationTest.java
@@ -50,13 +50,11 @@ public class ProtobufSerializationTest {
             .setSpec(
                 EntityProto.EntitySpecV2.newBuilder()
                     .setName("name")
-                    .setProject("project")
                     .setDescription("description")
                     .setValueType(ValueProto.ValueType.Enum.BOOL_LIST)
-                    .setJoinKey("joinKey")
                     .putLabels("key", "val"))
             .build();
-    Entity entity = new Entity(protoEntity);
+    Entity entity = new Entity("project", protoEntity);
     Assert.assertEquals(protoEntity, entity.toProto());
   }
 
@@ -83,13 +81,12 @@ public class ProtobufSerializationTest {
             .setSpec(
                 FeatureTableProto.FeatureTableSpec.newBuilder()
                     .setName("name")
-                    .setProject("project")
                     .setMaxAge(Duration.newBuilder().setSeconds(10).setNanos(10))
                     .addEntities("entity")
                     .putLabels("key", "val")
                     .addFeatures(FeatureProto.FeatureSpecV2.getDefaultInstance()))
             .build();
-    FeatureTable featureTable = new FeatureTable(featureTableProto);
+    FeatureTable featureTable = new FeatureTable("project", featureTableProto);
     Assert.assertEquals(featureTableProto, featureTable.toProto());
   }
 }

--- a/sdk/java/src/test/java/com/gojek/feast/core/ProtobufSerializationTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/core/ProtobufSerializationTest.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast.core;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import feast.proto.core.EntityProto;
+import feast.proto.core.FeatureProto;
+import feast.proto.core.FeatureTableProto;
+import feast.proto.types.ValueProto;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProtobufSerializationTest {
+  public static final Timestamp TIMESTAMP = Timestamp.newBuilder().setSeconds(100000).build();
+
+  @Test
+  public void testValueType() {
+    for (Descriptors.EnumValueDescriptor value :
+        ValueProto.ValueType.Enum.getDescriptor().getValues()) {
+      ValueType valueType = ValueType.valueOf(value.getName());
+      Assert.assertNotNull("ValueType enum=" + value.getName() + " Is missing.", valueType);
+      Assert.assertEquals(valueType.getNumber(), value.getNumber());
+    }
+  }
+
+  @Test
+  public void testEntity() {
+    EntityProto.Entity protoEntity =
+        EntityProto.Entity.newBuilder()
+            .setMeta(
+                EntityProto.EntityMeta.newBuilder()
+                    .setCreatedTimestamp(TIMESTAMP)
+                    .setLastUpdatedTimestamp(TIMESTAMP))
+            .setSpec(
+                EntityProto.EntitySpecV2.newBuilder()
+                    .setName("name")
+                    .setProject("project")
+                    .setDescription("description")
+                    .setValueType(ValueProto.ValueType.Enum.BOOL_LIST)
+                    .setJoinKey("joinKey")
+                    .putLabels("key", "val"))
+            .build();
+    Entity entity = new Entity(protoEntity);
+    Assert.assertEquals(protoEntity, entity.toProto());
+  }
+
+  @Test
+  public void testFeature() {
+    FeatureProto.FeatureSpecV2 featureProto =
+        FeatureProto.FeatureSpecV2.newBuilder()
+            .setName("name")
+            .setValueType(ValueProto.ValueType.Enum.BOOL)
+            .putLabels("key", "val")
+            .build();
+    Feature feature = new Feature(featureProto);
+    Assert.assertEquals(featureProto, feature.toProto());
+  }
+
+  @Test
+  public void testFeatureTable() {
+    FeatureTableProto.FeatureTable featureTableProto =
+        FeatureTableProto.FeatureTable.newBuilder()
+            .setMeta(
+                FeatureTableProto.FeatureTableMeta.newBuilder()
+                    .setCreatedTimestamp(TIMESTAMP)
+                    .setLastUpdatedTimestamp(TIMESTAMP))
+            .setSpec(
+                FeatureTableProto.FeatureTableSpec.newBuilder()
+                    .setName("name")
+                    .setProject("project")
+                    .setMaxAge(Duration.newBuilder().setSeconds(10).setNanos(10))
+                    .addEntities("entity")
+                    .putLabels("key", "val")
+                    .addFeatures(FeatureProto.FeatureSpecV2.getDefaultInstance()))
+            .build();
+    FeatureTable featureTable = new FeatureTable(featureTableProto);
+    Assert.assertEquals(featureTableProto, featureTable.toProto());
+  }
+}


### PR DESCRIPTION
This PR is meant to **add support for Core API via the java SDK client**, while **not breaking backwards compatibility**.
It comes as a followup to our conversation with @woop in out private [Salesforce slack channel](https://tectonfeast.slack.com/archives/C02B61KQK6J).

Waiting to hear from you on this. Thanks!